### PR TITLE
Single Side Explorer & Local Session Fixes

### DIFF
--- a/backend/source/backend/process/fork_pool.cpp
+++ b/backend/source/backend/process/fork_pool.cpp
@@ -10,9 +10,12 @@
 #include <spdlog/sinks/rotating_file_sink.h>
 #include <spdlog/spdlog.h>
 
+#include <algorithm>
+#include <cctype>
 #include <cstdint>
 #include <cstring>
 #include <filesystem>
+#include <fstream>
 #include <functional>
 #include <mutex>
 #include <string>
@@ -52,8 +55,8 @@ namespace
         int writeFd{-1};
         int sigFd{-1};
         FdJsonIo io;
-        std::unordered_map<std::string, WProc> procs;  // id  -> WProc
-        std::unordered_map<int, std::string> fdToId;   // pty master fd -> id
+        std::unordered_map<std::string, WProc> procs; // id  -> WProc
+        std::unordered_map<int, std::string> fdToId; // pty master fd -> id
         bool running{true};
 
         WorkerState(int readFd_, int writeFd_)
@@ -197,6 +200,8 @@ namespace
                     handleResize(procId, msg["payload"]);
                 else if (cmd == "kill")
                     handleKill(procId);
+                else if (cmd == "listProcesses")
+                    handleListProcesses(procId, msg["payload"]);
                 else
                     spdlog::warn("[worker] unknown command '{}' id='{}'", cmd, procId);
             }
@@ -252,7 +257,9 @@ namespace
             if (::openpty(&master, &slave, nullptr, &ttyOpts, &ws) == -1)
             {
                 spdlog::error("[worker] openpty failed for id='{}': {}", procId, std::strerror(errno));
-                sendJson({{"id", procId}, {"type", "error"}, {"message", std::string{"openpty: "} + std::strerror(errno)}});
+                sendJson(
+                    {{"id", procId}, {"type", "error"}, {"message", std::string{"openpty: "} + std::strerror(errno)}}
+                );
                 return;
             }
 
@@ -288,7 +295,9 @@ namespace
                 ::close(master);
                 ::close(slave);
                 spdlog::error("[worker] fork failed for id='{}': {}", procId, std::strerror(errno));
-                sendJson({{"id", procId}, {"type", "error"}, {"message", std::string{"fork: "} + std::strerror(errno)}});
+                sendJson(
+                    {{"id", procId}, {"type", "error"}, {"message", std::string{"fork: "} + std::strerror(errno)}}
+                );
                 return;
             }
 
@@ -298,11 +307,7 @@ namespace
                 ::close(master);
                 if (::login_tty(slave) == -1)
                     ::_exit(127);
-                ::execve(
-                    exe.c_str(),
-                    const_cast<char* const*>(argv.data()),
-                    const_cast<char* const*>(envp.data())
-                );
+                ::execve(exe.c_str(), const_cast<char* const*>(argv.data()), const_cast<char* const*>(envp.data()));
                 ::_exit(127);
             }
 
@@ -373,6 +378,88 @@ namespace
             };
             spdlog::debug("[worker] resize cols={} rows={} for id='{}'", ws.ws_col, ws.ws_row, procId);
             ::ioctl(it->second.ptyMaster, TIOCSWINSZ, &ws);
+        }
+
+        void handleListProcesses(std::string const& procId, nlohmann::json const& payload)
+        {
+            const auto responseId = payload.value("responseId", std::string{});
+
+            const auto it = procs.find(procId);
+            if (it == procs.end() || it->second.ptyMaster < 0)
+            {
+                sendJson(
+                    {{"id", procId},
+                        {"type", "listProcesses"},
+                        {"responseId", responseId},
+                        {"error", "no such process"}}
+                );
+                return;
+            }
+
+            char slaveName[256];
+            if (::ptsname_r(it->second.ptyMaster, slaveName, sizeof(slaveName)) != 0)
+            {
+                sendJson(
+                    {{"id", procId},
+                        {"type", "listProcesses"},
+                        {"responseId", responseId},
+                        {"error", std::string{"ptsname_r: "} + std::strerror(errno)}}
+                );
+                return;
+            }
+
+            nlohmann::json procsList = nlohmann::json::array();
+            try
+            {
+                for (const auto& entry : std::filesystem::directory_iterator("/proc"))
+                {
+                    try
+                    {
+                        if (!entry.is_directory())
+                            continue;
+                        const std::string pidStr = entry.path().filename().string();
+                        if (!std::all_of(
+                                pidStr.begin(),
+                                pidStr.end(),
+                                [](unsigned char chr)
+                                {
+                                    return std::isdigit(chr);
+                                }
+                            ))
+                            continue;
+                        const auto fdPath = entry.path() / "fd" / "0";
+                        if (!std::filesystem::is_symlink(fdPath))
+                            continue;
+                        std::error_code ec;
+                        const auto target = std::filesystem::read_symlink(fdPath, ec);
+                        if (ec || target.string() != slaveName)
+                            continue;
+                        std::ifstream cmdlineFile{entry.path() / "cmdline"};
+                        if (!cmdlineFile)
+                            continue;
+                        std::string cmdline;
+                        std::getline(cmdlineFile, cmdline, '\0');
+                        procsList.push_back({{"pid", std::stoi(pidStr)}, {"cmdline", cmdline}});
+                    }
+                    catch (...)
+                    {
+                        continue;
+                    }
+                }
+            }
+            catch (...)
+            {}
+
+            std::sort(
+                procsList.begin(),
+                procsList.end(),
+                [](nlohmann::json const& a, nlohmann::json const& b)
+                {
+                    return a["pid"].get<int>() < b["pid"].get<int>();
+                }
+            );
+
+            sendJson({{"id", procId}, {"type", "listProcesses"}, {"responseId", responseId}, {"procs", procsList}});
         }
 
         void handleKill(std::string const& procId)
@@ -456,9 +543,8 @@ namespace
             auto logPath = Nui::resolvePath("%state_home2%/nui-sftp/logs/worker.log");
             std::error_code mkdirEc;
             std::filesystem::create_directories(logPath.parent_path(), mkdirEc);
-            auto fileSink = std::make_shared<spdlog::sinks::rotating_file_sink_mt>(
-                logPath.string(), 2 * 1024 * 1024, 3, true
-            );
+            auto fileSink =
+                std::make_shared<spdlog::sinks::rotating_file_sink_mt>(logPath.string(), 2 * 1024 * 1024, 3, true);
             fileSink->set_level(spdlog::level::trace);
             auto logger = std::make_shared<spdlog::logger>("worker", std::move(fileSink));
             logger->set_level(spdlog::level::trace);

--- a/backend/source/backend/process/process_store.cpp
+++ b/backend/source/backend/process/process_store.cpp
@@ -200,6 +200,39 @@ void ProcessStore::handleWorkerMessage(nlohmann::json const& msg)
             }
         );
     }
+    else if (type == "listProcesses")
+    {
+        const auto responseId = msg.value("responseId", std::string{});
+        if (msg.contains("error"))
+        {
+            const auto errMsg = msg["error"].get<std::string>();
+            wnd_->runInJavascriptThread(
+                [this, responseId, errMsg]()
+                {
+                    hub_->callRemote(responseId, nlohmann::json{{"error", errMsg}});
+                }
+            );
+            return;
+        }
+        const auto procsList = msg["procs"];
+        wnd_->runInJavascriptThread(
+            [this, responseId, procsList]()
+            {
+                if (procsList.empty())
+                {
+                    hub_->callRemote(responseId, nlohmann::json{{"error", "No processes found"}});
+                    return;
+                }
+                nlohmann::json j = nlohmann::json::object();
+                j["latest"] = {
+                    {"pid", procsList.front()["pid"]},
+                    {"cmdline", procsList.front()["cmdline"]},
+                };
+                j["all"] = procsList;
+                hub_->callRemote(responseId, j);
+            }
+        );
+    }
     else if (type == "error")
     {
         Log::error("ForkPool worker error for process {}: {}", procId, msg.value("message", std::string{}));
@@ -549,6 +582,25 @@ void ProcessStore::registerRpc(Nui::Window& wnd, Nui::RpcHub& hub)
         {
             try
             {
+#ifndef _WIN32
+                {
+                    auto iter = forkPoolProcesses_.find(id);
+                    if (iter != forkPoolProcesses_.end())
+                    {
+                        if (forkPool_)
+                            forkPool_->send(
+                                nlohmann::json{
+                                    {"id", id},
+                                    {"command", "listProcesses"},
+                                    {"payload", {{"responseId", responseId}}},
+                                }
+                            );
+                        else
+                            hub->callRemote(responseId, nlohmann::json{{"error", "No fork pool available"}});
+                        return;
+                    }
+                }
+#endif
                 auto process = processes_.find(id);
                 if (process == processes_.end())
                 {

--- a/backend/source/backend/process/process_store.cpp
+++ b/backend/source/backend/process/process_store.cpp
@@ -196,7 +196,7 @@ void ProcessStore::handleWorkerMessage(nlohmann::json const& msg)
         wnd_->runInJavascriptThread(
             [this, procId]()
             {
-                hub_->callRemote("SessionArea::processDied", nlohmann::json{{"id", procId}});
+                hub_->callRemote("execTerminalExit_" + procId, nlohmann::json{{"id", procId}});
             }
         );
     }
@@ -266,7 +266,7 @@ void ProcessStore::notifyChildExit(Nui::RpcHub& hub, std::string const& id)
 
     process->second->exit();
     processes_.erase(process);
-    hub.callRemote("SessionArea::processDied", nlohmann::json{{"id", id}});
+    hub.callRemote("execTerminalExit_" + id, nlohmann::json{{"id", id}});
 }
 
 void ProcessStore::notifyChildExit(Nui::RpcHub& hub, long long pid)
@@ -278,7 +278,7 @@ void ProcessStore::notifyChildExit(Nui::RpcHub& hub, long long pid)
             process->exit();
             const auto idCopy = id;
             processes_.erase(id);
-            hub.callRemote("SessionArea::processDied", nlohmann::json{{"id", idCopy}, {"pid", pid}});
+            hub.callRemote("execTerminalExit_" + idCopy, nlohmann::json{{"id", idCopy}, {"pid", pid}});
             return;
         }
     }

--- a/frontend/include/frontend/session.hpp
+++ b/frontend/include/frontend/session.hpp
@@ -92,11 +92,11 @@ class Session
     void createExecutingEngine();
     void createSshEngine();
 
-    NuiFileExplorer::Side& remoteFileGridSide();
     NuiFileExplorer::Side& localFileGridSide();
+    NuiFileExplorer::Side* remoteFileGridSide();
 
-    RemoteSideModel& remoteSideModel();
     LocalSideModel& localSideModel();
+    RemoteSideModel* remoteSideModel();
 
     void loadLayoutExtras(nlohmann::json const& layoutExtra);
 

--- a/frontend/include/frontend/terminal/executing_channel.hpp
+++ b/frontend/include/frontend/terminal/executing_channel.hpp
@@ -3,6 +3,7 @@
 #include <frontend/terminal/channel_interface.hpp>
 #include <ids/ids.hpp>
 #include <nui/rpc.hpp>
+#include <nui/frontend/api/timer.hpp>
 
 #include <functional>
 #include <string>
@@ -18,16 +19,18 @@ class ExecutingChannel : public ChannelInterface
 {
   public:
     /**
-     * @param channelId       The process UUID returned by ProcessStore::spawn.
-     * @param stdoutReceiver  Already-registered receiver for stdout data.
-     * @param stderrReceiver  Already-registered receiver for stderr data.
-     * @param exitReceiver    Already-registered receiver for process exit.
+     * @param channelId        The process UUID returned by ProcessStore::spawn.
+     * @param stdoutReceiver   Already-registered receiver for stdout data.
+     * @param stderrReceiver   Already-registered receiver for stderr data.
+     * @param exitReceiver     Already-registered receiver for process exit.
+     * @param onProcessChange  Called with the current foreground process cmdline after writes.
      */
     ExecutingChannel(
         Ids::ChannelId channelId,
         Nui::RpcClient::AutoUnregister stdoutReceiver,
         Nui::RpcClient::AutoUnregister stderrReceiver,
-        Nui::RpcClient::AutoUnregister exitReceiver
+        Nui::RpcClient::AutoUnregister exitReceiver,
+        std::function<void(std::string const&)> onProcessChange
     );
     ~ExecutingChannel() override = default;
     ExecutingChannel(ExecutingChannel&&) = default;
@@ -55,8 +58,12 @@ class ExecutingChannel : public ChannelInterface
     }
 
   private:
+    void updatePtyProcs();
+
     Ids::ChannelId channelId_;
     Nui::RpcClient::AutoUnregister stdoutReceiver_;
     Nui::RpcClient::AutoUnregister stderrReceiver_;
     Nui::RpcClient::AutoUnregister exitReceiver_;
+    std::function<void(std::string const&)> onProcessChange_;
+    Nui::TimerHandle procInfoTimer_;
 };

--- a/frontend/include/frontend/terminal/executing_channel.hpp
+++ b/frontend/include/frontend/terminal/executing_channel.hpp
@@ -23,14 +23,14 @@ class ExecutingChannel : public ChannelInterface
      * @param stdoutReceiver   Already-registered receiver for stdout data.
      * @param stderrReceiver   Already-registered receiver for stderr data.
      * @param exitReceiver     Already-registered receiver for process exit.
-     * @param onProcessChange  Called with the current foreground process cmdline after writes.
+     * @param onProcessChange  Called with the channel id and current foreground process cmdline after writes.
      */
     ExecutingChannel(
         Ids::ChannelId channelId,
         Nui::RpcClient::AutoUnregister stdoutReceiver,
         Nui::RpcClient::AutoUnregister stderrReceiver,
         Nui::RpcClient::AutoUnregister exitReceiver,
-        std::function<void(std::string const&)> onProcessChange
+        std::function<void(Ids::ChannelId const&, std::string const&)> onProcessChange
     );
     ~ExecutingChannel() override = default;
     ExecutingChannel(ExecutingChannel&&) = default;
@@ -64,6 +64,6 @@ class ExecutingChannel : public ChannelInterface
     Nui::RpcClient::AutoUnregister stdoutReceiver_;
     Nui::RpcClient::AutoUnregister stderrReceiver_;
     Nui::RpcClient::AutoUnregister exitReceiver_;
-    std::function<void(std::string const&)> onProcessChange_;
+    std::function<void(Ids::ChannelId const&, std::string const&)> onProcessChange_;
     Nui::TimerHandle procInfoTimer_;
 };

--- a/frontend/include/frontend/terminal/executing_engine.hpp
+++ b/frontend/include/frontend/terminal/executing_engine.hpp
@@ -4,6 +4,7 @@
 #include <frontend/terminal/terminal_engine.hpp>
 #include <roar/detail/pimpl_special_functions.hpp>
 #include <persistence/state/session_options.hpp>
+#include <ids/ids.hpp>
 #include <nui/utility/move_detector.hpp>
 
 #include <memory>
@@ -24,7 +25,7 @@ class ExecutingTerminalEngine : public TerminalEngine
     {
         Persistence::ExecutingSessionOptions engineOptions;
         Persistence::Termios termios;
-        std::function<void(std::string)> onProcessChange;
+        std::function<void(Ids::ChannelId const&, std::string)> onProcessChange;
     };
 
   public:

--- a/frontend/source/frontend/file_explorer/local_side_model.cpp
+++ b/frontend/source/frontend/file_explorer/local_side_model.cpp
@@ -281,6 +281,18 @@ void LocalSideModel::onTransfer(
     if (items.empty())
         return;
 
+    if (!remoteModel_)
+    {
+        Log::error("Cannot transfer items: remote model is not set");
+        confirmDialog_->open({
+            .styleVariant = ScriptNuiComponents::StyleVariant::Danger,
+            .headerText = "File Transfer Failed",
+            .text = "Remote side is not available",
+            .buttons = ConfirmDialog::Button::Ok,
+        });
+        return;
+    }
+
     Log::info("Upload items requested: {}", items.size());
     for (const auto& item : items)
     {
@@ -844,7 +856,7 @@ void LocalSideModel::setRemoteModel(SideModel* model)
 
 bool LocalSideModel::isComplete() const
 {
-    return remoteModel_ != nullptr && SideModel::isComplete();
+    return SideModel::isComplete();
 }
 
 void LocalSideModel::generatePathBoxSuggestions(

--- a/frontend/source/frontend/file_explorer/local_side_model.cpp
+++ b/frontend/source/frontend/file_explorer/local_side_model.cpp
@@ -748,17 +748,25 @@ LocalSideModel::contextMenuItems(std::vector<NuiFileExplorer::Item> const& selec
     const bool hasItems = !selectedItems.empty();
     const bool singleItem = selectedItems.size() == 1;
 
-    return {
-        Snc::PopupMenu::item(
-            language->get("fileExplorer", "contextMenu", "upload"),
-            {},
-            [this, selectedItems]()
-            {
-                onTransfer(selectedItems, std::nullopt);
-            },
-            !hasItems
-        ),
-        Snc::PopupMenu::separator(),
+    std::vector<NuiFileExplorer::ContextMenuItem> items;
+
+    if (remoteModel_)
+    {
+        items.push_back(
+            Snc::PopupMenu::item(
+                language->get("fileExplorer", "contextMenu", "upload"),
+                {},
+                [this, selectedItems]()
+                {
+                    onTransfer(selectedItems, std::nullopt);
+                },
+                !hasItems
+            )
+        );
+        items.push_back(Snc::PopupMenu::separator());
+    }
+
+    const auto remainingItems = std::vector<NuiFileExplorer::ContextMenuItem>{
         Snc::PopupMenu::item(
             language->get("fileExplorer", "contextMenu", "open"),
             {},
@@ -806,6 +814,9 @@ LocalSideModel::contextMenuItems(std::vector<NuiFileExplorer::Item> const& selec
             !singleItem
         ),
     };
+
+    items.insert(items.end(), remainingItems.begin(), remainingItems.end());
+    return items;
 }
 
 void LocalSideModel::onOpen(NuiFileExplorer::Item const& item, bool openWith)

--- a/frontend/source/frontend/session.cpp
+++ b/frontend/source/frontend/session.cpp
@@ -127,28 +127,46 @@ struct Session::Implementation
         , options{this->engineOptions.terminalOptions.value()}
         , inputDialog{inputDialog}
         , confirmDialog{confirmDialog}
-        , fileGrid{{
-              .pathBarOnTop = uiOptions.fileGridPathBarOnTop,
-              .showHiddenFiles = uiOptions.showHiddenFilesLocally,
-              .onShowHiddenFilesChanged = [this](bool value) {
-                  this->stateHolder->loadModifySave([value](Persistence::State& state) {
-                      state.uiOptions.showHiddenFilesLocally = value;
-                  });
-              },
-         }, {
-                .pathBarOnTop = uiOptions.fileGridPathBarOnTop,
-                .showHiddenFiles = uiOptions.showHiddenFilesRemotely,
-                .onShowHiddenFilesChanged = [this](bool value) {
-                    this->stateHolder->loadModifySave([value](Persistence::State& state) {
-                        state.uiOptions.showHiddenFilesRemotely = value;
-                    });
+        , fileGrid{[this, &engineOptions, &uiOptions, confirmDialog, inputDialog, filePropertyDialog]() -> NuiFileExplorer::FileGrid {
+            if (std::holds_alternative<Persistence::SshSessionOptions>(engineOptions.engine))
+            {
+                return {{
+                    .pathBarOnTop = uiOptions.fileGridPathBarOnTop,
+                    .showHiddenFiles = uiOptions.showHiddenFilesLocally,
+                    .onShowHiddenFilesChanged = [this](bool value) {
+                        this->stateHolder->loadModifySave([value](Persistence::State& state) {
+                            state.uiOptions.showHiddenFilesLocally = value;
+                        });
+                    },
+                }, {
+                        .pathBarOnTop = uiOptions.fileGridPathBarOnTop,
+                        .showHiddenFiles = uiOptions.showHiddenFilesRemotely,
+                        .onShowHiddenFilesChanged = [this](bool value) {
+                            this->stateHolder->loadModifySave([value](Persistence::State& state) {
+                                state.uiOptions.showHiddenFilesRemotely = value;
+                            });
+                        },
                 },
-         },
-            std::make_unique<LocalSideModel>(this->uiOptions, confirmDialog, inputDialog, filePropertyDialog),
-            std::make_unique<RemoteSideModel>(this->uiOptions, confirmDialog, inputDialog, filePropertyDialog),
-        }
+                    std::make_unique<LocalSideModel>(this->uiOptions, confirmDialog, inputDialog, filePropertyDialog),
+                    std::make_unique<RemoteSideModel>(this->uiOptions, confirmDialog, inputDialog, filePropertyDialog),
+                };
+            } else {
+                // Local only
+                return {{
+                    .pathBarOnTop = uiOptions.fileGridPathBarOnTop,
+                    .showHiddenFiles = uiOptions.showHiddenFilesLocally,
+                    .onShowHiddenFilesChanged = [this](bool value) {
+                        this->stateHolder->loadModifySave([value](Persistence::State& state) {
+                            state.uiOptions.showHiddenFilesLocally = value;
+                        });
+                    },
+                },
+                    std::make_unique<LocalSideModel>(this->uiOptions, confirmDialog, inputDialog, filePropertyDialog)
+                };
+            }
+        }()}
         , fileExplorerElement{}
-        , operationQueue{this->stateHolder, this->events, this->initialName, this->confirmDialog, static_cast<LocalSideModel*>(&fileGrid.leftModel()), static_cast<RemoteSideModel*>(&fileGrid.rightModel())}
+        , operationQueue{this->stateHolder, this->events, this->initialName, this->confirmDialog, static_cast<LocalSideModel*>(&fileGrid.leftModel()), static_cast<RemoteSideModel*>(fileGrid.rightModel())}
         , operationQueueElement{}
         , layoutHost{}
         , layoutName{std::move(layoutName)}
@@ -161,7 +179,8 @@ struct Session::Implementation
         , disambiguateTitle{std::move(disambiguateTitle)}
     {
         fileGrid.leftModel().dropMetadata(sessionLayoutId);
-        fileGrid.rightModel().dropMetadata(sessionLayoutId);
+        if (fileGrid.rightModel())
+            fileGrid.rightModel()->dropMetadata(sessionLayoutId);
 
         using namespace ScriptNuiComponents;
         using namespace std::string_literals;
@@ -417,7 +436,7 @@ void Session::onChannelLoss(Ids::ChannelId const& id)
     );
 }
 
-NuiFileExplorer::Side& Session::remoteFileGridSide()
+NuiFileExplorer::Side* Session::remoteFileGridSide()
 {
     return impl_->fileGrid.rightSide();
 }
@@ -514,14 +533,14 @@ std::optional<nlohmann::json> Session::getLayout() const
                     {"flavor", fileGridFlavorToString(impl_->fileGrid.leftSide().flavor())},
                 },
             },
-            {
-                "rightSide",
-                {
-                    {"flavor", fileGridFlavorToString(impl_->fileGrid.rightSide().flavor())},
-                },
-            },
         },
     }};
+    if (impl_->fileGrid.rightSide())
+    {
+        layoutObject["__extra"]["fileGrid"]["rightSide"] = {
+            {"flavor", fileGridFlavorToString(impl_->fileGrid.rightSide()->flavor())},
+        };
+    }
     return layoutObject;
 }
 
@@ -541,20 +560,29 @@ void Session::setupFileGrid()
         }
     );
 
-    remoteSideModel().setItemUpdateFunction(
-        [this](bool sorted, bool reapplySelection)
-        {
-            remoteFileGridSide().updateItems(sorted, reapplySelection);
-        }
-    );
+    if (remoteSideModel())
+    {
+        remoteSideModel()->setItemUpdateFunction(
+            [this](bool sorted, bool reapplySelection)
+            {
+                if (remoteFileGridSide())
+                    remoteFileGridSide()->updateItems(sorted, reapplySelection);
+            }
+        );
+    }
     localSideModel().setItemUpdateFunction(
         [this](bool sorted, bool reapplySelection)
         {
             localFileGridSide().updateItems(sorted, reapplySelection);
         }
     );
-    remoteSideModel().setLocalModel(&localSideModel());
-    localSideModel().setRemoteModel(&remoteSideModel());
+    if (remoteSideModel())
+    {
+        remoteSideModel()->setLocalModel(&localSideModel());
+        localSideModel().setRemoteModel(remoteSideModel());
+    }
+    else
+        localSideModel().setRemoteModel(nullptr);
 }
 
 void Session::saveTerminalContents(std::filesystem::path const& file, std::vector<std::string> const& contents)
@@ -724,19 +752,41 @@ void Session::openSftp(std::string const& username)
             Log::info("Opening SFTP by default");
             auto* sshTerminalEngine = static_cast<SshTerminalEngine*>(&impl_->frontendSessionManager.value()->engine());
             auto fileEngine = std::make_shared<FileEngine>(sshTerminalEngine);
-            remoteSideModel().engine(fileEngine);
+
+            if (!remoteSideModel())
+            {
+                Log::error(
+                    "Remote side model is not available, cannot open SFTP. This is a bug and should not happen by "
+                    "design."
+                );
+                impl_->confirmDialog->open({
+                    .styleVariant = ScriptNuiComponents::StyleVariant::Danger,
+                    .headerText = "SFTP Initialization Failed",
+                    .text = "Remote side model is not available, cannot open SFTP. This is a bug and should not happen "
+                            "by design.",
+                    .buttons = ConfirmDialog::Button::Ok,
+                    .neverShowAgainId = "sftpInitializationFailed",
+                });
+            }
+
+            if (remoteSideModel())
+                remoteSideModel()->engine(fileEngine);
             localSideModel().engine(std::move(fileEngine));
-            impl_->operationQueue.activate(remoteSideModel().engine(), sshTerminalEngine->sshSessionId());
+            if (remoteSideModel())
+                impl_->operationQueue.activate(remoteSideModel()->engine(), sshTerminalEngine->sshSessionId());
             impl_->fileTrackingPanel.activate(&impl_->operationQueue, sshTerminalEngine->sshSessionId());
-            remoteSideModel().operationQueue(&impl_->operationQueue);
-            remoteSideModel().setFileTracking(&impl_->fileTrackingPanel);
             localSideModel().operationQueue(&impl_->operationQueue);
-            remoteFileGridSide().path(
-                fmt::format(
-                    fmt::runtime(opts.sftpOptions->defaultDirectory.value_or("/home/{user}").generic_string()),
-                    fmt::arg("user", username)
-                )
-            );
+            if (remoteSideModel())
+            {
+                remoteSideModel()->operationQueue(&impl_->operationQueue);
+                remoteSideModel()->setFileTracking(&impl_->fileTrackingPanel);
+                remoteFileGridSide()->path(
+                    fmt::format(
+                        fmt::runtime(opts.sftpOptions->defaultDirectory.value_or("/home/{user}").generic_string()),
+                        fmt::arg("user", username)
+                    )
+                );
+            }
             openLocalFilesystem();
         }
     }
@@ -895,7 +945,8 @@ void Session::closeSelf()
             impl_->closeSelf(this);
     };
 
-    if (!isExecutingEngine && (impl_->frontendSessionManager.value() || remoteSideModel().engine()))
+    if (!isExecutingEngine &&
+        (impl_->frontendSessionManager.value() || (remoteSideModel() && remoteSideModel()->engine())))
     {
         Log::info("Session shutdown started.");
 
@@ -917,7 +968,7 @@ void Session::closeSelf()
         };
 
         // Not necessary, because the session destruction will take care of it:
-        // if (auto fileEngine = remoteSideModel().engine(); fileEngine)
+        // if (auto fileEngine = remoteSideModel()->engine(); fileEngine)
         // {
         //     Log::info("Disposing file engine.");
         //     fileEngine->dispose(terminalDispose);
@@ -1020,9 +1071,10 @@ void Session::loadLayoutExtras(nlohmann::json const& layoutExtra)
                 NuiFileExplorer::fileGridFlavorFromString(fileGridExtra["leftSide"]["flavor"].get<std::string>())
             );
         }
-        if (fileGridExtra.contains("rightSide") && fileGridExtra["rightSide"].contains("flavor"))
+        if (fileGridExtra.contains("rightSide") && fileGridExtra["rightSide"].contains("flavor") &&
+            impl_->fileGrid.rightSide())
         {
-            impl_->fileGrid.rightSide().flavor(
+            impl_->fileGrid.rightSide()->flavor(
                 NuiFileExplorer::fileGridFlavorFromString(fileGridExtra["rightSide"]["flavor"].get<std::string>())
             );
         }
@@ -1322,9 +1374,11 @@ Nui::ElementRenderer Session::operator()()
     // clang-format on
 }
 
-RemoteSideModel& Session::remoteSideModel()
+RemoteSideModel* Session::remoteSideModel()
 {
-    return static_cast<RemoteSideModel&>(remoteFileGridSide().model());
+    if (!remoteFileGridSide())
+        return nullptr;
+    return static_cast<RemoteSideModel*>(&remoteFileGridSide()->model());
 }
 LocalSideModel& Session::localSideModel()
 {

--- a/frontend/source/frontend/session.cpp
+++ b/frontend/source/frontend/session.cpp
@@ -185,7 +185,7 @@ struct Session::Implementation
         using namespace ScriptNuiComponents;
         using namespace std::string_literals;
 
-        tabAddMenu.setItems({
+        auto tabAddMenuItems = std::vector<PopupMenu::Entry>{
             PopupMenu::sectionHeader("New Tab"),
             PopupMenu::item(
                 language->get("sessionFrontend", "terminal"),
@@ -208,59 +208,66 @@ struct Session::Implementation
                     Nui::val::global("contentPanelManager").call<void>("fullfillLastAddRequest", "file-explorer"s);
                 }
             ),
-            PopupMenu::item(
-                language->get("sessionFrontend", "operationQueue"),
-                {},
-                [this]()
-                {
-                    tabAddMenu.close();
-                    // There can only be one!
-                    if (operationQueueElement.value())
-                        return;
-                    Nui::val::global("contentPanelManager").call<void>("fullfillLastAddRequest", "operation-queue"s);
-                }
-            ),
-            PopupMenu::item(
-                language->get("sessionFrontend", "sessionOptions"),
-                {},
-                [this]()
-                {
-                    tabAddMenu.close();
-                    // There can only be one!
-                    if (sessionOptionsElement.value())
-                        return;
-                    Nui::val::global("contentPanelManager").call<void>("fullfillLastAddRequest", "session-options"s);
-                }
-            ),
-            PopupMenu::item(
-                language->get("sessionFrontend", "fileTracking"),
-                {},
-                [this]()
-                {
-                    tabAddMenu.close();
-                    // There can only be one!
-                    if (fileTrackingElement.value())
-                        return;
-                    Nui::val::global("contentPanelManager").call<void>("fullfillLastAddRequest", "file-tracking"s);
-                }
-            ),
-        });
+            // Not needed currently:
+            // PopupMenu::item(
+            //     language->get("sessionFrontend", "sessionOptions"),
+            //     {},
+            //     [this]()
+            //     {
+            //         tabAddMenu.close();
+            //         // There can only be one!
+            //         if (sessionOptionsElement.value())
+            //             return;
+            //         Nui::val::global("contentPanelManager").call<void>("fullfillLastAddRequest", "session-options"s);
+            //     }
+            // ),
+        };
+
+        if (std::holds_alternative<Persistence::SshSessionOptions>(engineOptions.engine))
+        {
+            tabAddMenuItems.push_back(
+                PopupMenu::item(
+                    language->get("sessionFrontend", "operationQueue"),
+                    {},
+                    [this]()
+                    {
+                        tabAddMenu.close();
+                        // There can only be one!
+                        if (operationQueueElement.value())
+                            return;
+                        Nui::val::global("contentPanelManager")
+                            .call<void>("fullfillLastAddRequest", "operation-queue"s);
+                    }
+                )
+            );
+            tabAddMenuItems.push_back(
+                PopupMenu::item(
+                    language->get("sessionFrontend", "fileTracking"),
+                    {},
+                    [this]()
+                    {
+                        tabAddMenu.close();
+                        // There can only be one!
+                        if (fileTrackingElement.value())
+                            return;
+                        Nui::val::global("contentPanelManager").call<void>("fullfillLastAddRequest", "file-tracking"s);
+                    }
+                )
+            );
+        }
+
+        tabAddMenu.setItems(std::move(tabAddMenuItems));
 
         sessionOptionsListener = Nui::smartListen(
             sessionOptionsElement,
             [this](std::shared_ptr<Nui::Dom::Element> const& elem)
             {
-                sessionOptionsElement.eventContext().delayToAfterProcessing(
-                    [this, elem]()
+                tabAddMenu.modifyItemByLabel(
+                    language->get("sessionFrontend", "sessionOptions"),
+                    [dis = elem != nullptr](ScriptNuiComponents::PopupMenu::MenuItem* mi)
                     {
-                        tabAddMenu.modifyItemByLabel(
-                            language->get("sessionFrontend", "sessionOptions"),
-                            [dis = elem != nullptr](ScriptNuiComponents::PopupMenu::MenuItem* mi)
-                            {
-                                if (mi)
-                                    mi->disabled = dis;
-                            }
-                        );
+                        if (mi)
+                            mi->disabled = dis;
                     }
                 );
             }
@@ -270,22 +277,15 @@ struct Session::Implementation
             [this](std::shared_ptr<Nui::Dom::Element> const& elem)
             {
                 Nui::WebApi::Console::log("fileExplorerElement changed.");
-                fileExplorerElement.eventContext().delayToAfterProcessing(
-                    [this, elem]()
+                tabAddMenu.modifyItemByLabel(
+                    language->get("sessionFrontend", "fileExplorer"),
+                    [dis = elem != nullptr](ScriptNuiComponents::PopupMenu::MenuItem* mi)
                     {
-                        tabAddMenu.modifyItemByLabel(
-                            language->get("sessionFrontend", "fileExplorer"),
-                            [dis = elem != nullptr](ScriptNuiComponents::PopupMenu::MenuItem* mi)
-                            {
-                                if (mi)
-                                {
-                                    Nui::WebApi::Console::log(
-                                        "Menu item found, modifying disabled to " + std::to_string(dis)
-                                    );
-                                    mi->disabled = dis;
-                                }
-                            }
-                        );
+                        if (mi)
+                        {
+                            Nui::WebApi::Console::log("Menu item found, modifying disabled to " + std::to_string(dis));
+                            mi->disabled = dis;
+                        }
                     }
                 );
             }
@@ -296,17 +296,12 @@ struct Session::Implementation
             {
                 Nui::WebApi::Console::log("operationQueueElement changed.");
 
-                operationQueueElement.eventContext().delayToAfterProcessing(
-                    [this, elem]()
+                tabAddMenu.modifyItemByLabel(
+                    language->get("sessionFrontend", "operationQueue"),
+                    [dis = elem != nullptr](ScriptNuiComponents::PopupMenu::MenuItem* mi)
                     {
-                        tabAddMenu.modifyItemByLabel(
-                            language->get("sessionFrontend", "operationQueue"),
-                            [dis = elem != nullptr](ScriptNuiComponents::PopupMenu::MenuItem* mi)
-                            {
-                                if (mi)
-                                    mi->disabled = dis;
-                            }
-                        );
+                        if (mi)
+                            mi->disabled = dis;
                     }
                 );
             }
@@ -315,17 +310,12 @@ struct Session::Implementation
             fileTrackingElement,
             [this](std::shared_ptr<Nui::Dom::Element> const& elem)
             {
-                fileTrackingElement.eventContext().delayToAfterProcessing(
-                    [this, elem]()
+                tabAddMenu.modifyItemByLabel(
+                    language->get("sessionFrontend", "fileTracking"),
+                    [dis = elem != nullptr](ScriptNuiComponents::PopupMenu::MenuItem* mi)
                     {
-                        tabAddMenu.modifyItemByLabel(
-                            language->get("sessionFrontend", "fileTracking"),
-                            [dis = elem != nullptr](ScriptNuiComponents::PopupMenu::MenuItem* mi)
-                            {
-                                if (mi)
-                                    mi->disabled = dis;
-                            }
-                        );
+                        if (mi)
+                            mi->disabled = dis;
                     }
                 );
             }
@@ -1130,6 +1120,7 @@ void Session::initializeLayout()
     auto addPanelArgument = Nui::val::object();
     addPanelArgument.set("host", element);
     addPanelArgument.set("id", impl_->sessionLayoutId);
+    addPanelArgument.set("engineType", impl_->frontendSessionManager.value()->engine().engineName());
     addPanelArgument.set("layoutString", layout ? Nui::val(layout->dump()) : Nui::val::undefined());
     addPanelArgument.set(
         "terminalFactory",

--- a/frontend/source/frontend/session.cpp
+++ b/frontend/source/frontend/session.cpp
@@ -673,10 +673,12 @@ void Session::createExecutingEngine()
             .engineOptions = std::get<Persistence::ExecutingSessionOptions>(impl_->engineOptions.engine),
             .termios = impl_->engineOptions.termios.value(),
             .onProcessChange =
-                [this](std::string const& cmdline)
+                [this](Ids::ChannelId const& channelId, std::string const& cmdline)
             {
                 Log::info("Tab title changed: {}", cmdline);
                 *impl_->tabTitle = impl_->disambiguateTitle(this, cmdline);
+                Nui::val::global("contentPanelManager")
+                    .call<void>("renameTerminalById", impl_->sessionLayoutId, channelId.value(), cmdline);
                 Nui::globalEventContext.executeActiveEventsImmediately();
             },
         }),

--- a/frontend/source/frontend/session.cpp
+++ b/frontend/source/frontend/session.cpp
@@ -502,7 +502,7 @@ Session::Session(
     if (std::holds_alternative<Persistence::ExecutingSessionOptions>(impl_->engineOptions.engine))
     {
         createExecutingEngine();
-        // what about files?
+        setupFileGrid();
     }
     else if (std::holds_alternative<Persistence::SshSessionOptions>(impl_->engineOptions.engine))
     {
@@ -696,6 +696,8 @@ void Session::createExecutingEngine()
     impl_->frontendSessionManager.value()->open(
         std::bind(&Session::onOpenSession, this, std::placeholders::_1, std::placeholders::_2)
     );
+
+    openLocalFilesystem();
 }
 
 Session::~Session() = default;

--- a/frontend/source/frontend/session_components/operation_queue.cpp
+++ b/frontend/source/frontend/session_components/operation_queue.cpp
@@ -372,7 +372,8 @@ void OperationQueue::onOperationAdded(SharedData::OperationAdded const& added)
         if (added.insertRefresh)
             remoteRefresh = [this]()
             {
-                impl_->remoteModel->onRefresh();
+                if (impl_->remoteModel)
+                    impl_->remoteModel->onRefresh();
             };
 
         Log::info("Operation of type '{}' added to frontend queue", Utility::enumToString(added.type));

--- a/frontend/source/frontend/terminal/executing_channel.cpp
+++ b/frontend/source/frontend/terminal/executing_channel.cpp
@@ -57,11 +57,14 @@ void ExecutingChannel::updatePtyProcs()
                     if (val.hasOwnProperty("latest"))
                     {
                         if (onProcessChange_)
-                            onProcessChange_(channelId_, fmt::format(
-                                "{} ({})",
-                                val["latest"]["cmdline"].as<std::string>(),
-                                val["latest"]["pid"].as<int>()
-                            ));
+                            onProcessChange_(
+                                channelId_,
+                                fmt::format(
+                                    "{} ({})",
+                                    val["latest"]["cmdline"].as<std::string>(),
+                                    val["latest"]["pid"].as<int>()
+                                )
+                            );
                     }
                     else
                     {
@@ -85,6 +88,8 @@ void ExecutingChannel::resize(int cols, int rows)
 
 void ExecutingChannel::dispose(std::function<void()> onExit)
 {
+    Log::info("ExecutingChannel: disposing channelId={}", channelId_.value());
+
     // Unregister receivers before telling the backend to exit so no stale
     // callbacks fire after the process is gone.
     stdoutReceiver_.reset();

--- a/frontend/source/frontend/terminal/executing_channel.cpp
+++ b/frontend/source/frontend/terminal/executing_channel.cpp
@@ -6,13 +6,18 @@ ExecutingChannel::ExecutingChannel(
     Ids::ChannelId channelId,
     Nui::RpcClient::AutoUnregister stdoutReceiver,
     Nui::RpcClient::AutoUnregister stderrReceiver,
-    Nui::RpcClient::AutoUnregister exitReceiver
+    Nui::RpcClient::AutoUnregister exitReceiver,
+    std::function<void(std::string const&)> onProcessChange
 )
     : channelId_{std::move(channelId)}
     , stdoutReceiver_{std::move(stdoutReceiver)}
     , stderrReceiver_{std::move(stderrReceiver)}
     , exitReceiver_{std::move(exitReceiver)}
-{}
+    , onProcessChange_{std::move(onProcessChange)}
+    , procInfoTimer_{}
+{
+    updatePtyProcs();
+}
 
 void ExecutingChannel::open(
     std::function<void(std::string const&)>,
@@ -27,23 +32,55 @@ void ExecutingChannel::open(
 
 void ExecutingChannel::write(std::string const& data)
 {
+    if (!data.empty() && (data.back() == '\r' || data.back() == '\n'))
+        updatePtyProcs();
+
     Nui::RpcClient::callWithBackChannel(
-        "ProcessStore::write",
-        [](Nui::val) {},
-        channelId_.value(),
-        Nui::val::global("btoa")(data).as<std::string>()
+        "ProcessStore::write", [](Nui::val) {}, channelId_.value(), Nui::val::global("btoa")(data).as<std::string>()
+    );
+}
+
+void ExecutingChannel::updatePtyProcs()
+{
+    if (procInfoTimer_.hasActiveTimer())
+        return;
+
+    Nui::setTimeout(
+        500,
+        [this]()
+        {
+            Log::info("ExecutingChannel: querying ptyProcesses for channelId={}", channelId_.value());
+            Nui::RpcClient::callWithBackChannel(
+                "ProcessStore::ptyProcesses",
+                [this](Nui::val val)
+                {
+                    if (val.hasOwnProperty("latest"))
+                    {
+                        if (onProcessChange_)
+                            onProcessChange_(fmt::format(
+                                "{} ({})",
+                                val["latest"]["cmdline"].as<std::string>(),
+                                val["latest"]["pid"].as<int>()
+                            ));
+                    }
+                    else
+                    {
+                        Log::warn("ptyProcesses did not return latest: {}", Nui::JSON::stringify(val));
+                    }
+                },
+                channelId_.value()
+            );
+        },
+        [this](Nui::TimerHandle&& handle)
+        {
+            procInfoTimer_ = std::move(handle);
+        }
     );
 }
 
 void ExecutingChannel::resize(int cols, int rows)
 {
-    Nui::RpcClient::callWithBackChannel(
-        "ProcessStore::ptyResize",
-        [](Nui::val) {},
-        channelId_.value(),
-        cols,
-        rows
-    );
+    Nui::RpcClient::callWithBackChannel("ProcessStore::ptyResize", [](Nui::val) {}, channelId_.value(), cols, rows);
 }
 
 void ExecutingChannel::dispose(std::function<void()> onExit)

--- a/frontend/source/frontend/terminal/executing_channel.cpp
+++ b/frontend/source/frontend/terminal/executing_channel.cpp
@@ -7,7 +7,7 @@ ExecutingChannel::ExecutingChannel(
     Nui::RpcClient::AutoUnregister stdoutReceiver,
     Nui::RpcClient::AutoUnregister stderrReceiver,
     Nui::RpcClient::AutoUnregister exitReceiver,
-    std::function<void(std::string const&)> onProcessChange
+    std::function<void(Ids::ChannelId const&, std::string const&)> onProcessChange
 )
     : channelId_{std::move(channelId)}
     , stdoutReceiver_{std::move(stdoutReceiver)}
@@ -57,7 +57,7 @@ void ExecutingChannel::updatePtyProcs()
                     if (val.hasOwnProperty("latest"))
                     {
                         if (onProcessChange_)
-                            onProcessChange_(fmt::format(
+                            onProcessChange_(channelId_, fmt::format(
                                 "{} ({})",
                                 val["latest"]["cmdline"].as<std::string>(),
                                 val["latest"]["pid"].as<int>()

--- a/frontend/source/frontend/terminal/executing_engine.cpp
+++ b/frontend/source/frontend/terminal/executing_engine.cpp
@@ -203,9 +203,13 @@ void ExecutingTerminalEngine::createChannel(
             );
             auto sharedExit = std::make_shared<Nui::RpcClient::AutoUnregister>(std::move(exitReceiver));
 
-            impl_->channels.emplace(
+            impl_->channels.try_emplace(
                 channelId,
-                ExecutingChannel{channelId, std::move(*sharedStdout), std::move(*sharedStderr), std::move(*sharedExit)}
+                channelId,
+                std::move(*sharedStdout),
+                std::move(*sharedStderr),
+                std::move(*sharedExit),
+                impl_->settings.onProcessChange
             );
 
             Log::info(

--- a/frontend/source/frontend/terminal/frontend_session_manager.cpp
+++ b/frontend/source/frontend/terminal/frontend_session_manager.cpp
@@ -47,9 +47,7 @@ bool FrontendSessionManager::guardDisposal() const
     return false;
 }
 
-void FrontendSessionManager::forEachChannel(
-    std::function<bool(Ids::ChannelId const&, TerminalChannel&)> const& handler
-)
+void FrontendSessionManager::forEachChannel(std::function<bool(Ids::ChannelId const&, TerminalChannel&)> const& handler)
 {
     if (guardDisposal())
         return;
@@ -202,7 +200,13 @@ void FrontendSessionManager::closeChannel(Ids::ChannelId const& channelId)
     if (auto found = impl_->channels.find(channelId); found != impl_->channels.end())
     {
         Log::info("Closing channel: '{}'", channelId.value());
-        impl_->channels.erase(found);
+        found->second->dispose(
+            [this, channelId]()
+            {
+                impl_->channels.erase(channelId);
+            },
+            true // also close backend resources immediately
+        );
     }
 }
 
@@ -212,6 +216,17 @@ void FrontendSessionManager::closeAllChannels()
         return;
 
     Log::info("Closing all channels");
+    for (auto& [id, channel] : impl_->channels)
+    {
+        Log::info("Disposing channel as part of closeAllChannels: '{}'", id.value());
+        channel->dispose(
+            []()
+            {
+                Log::info("Disposed channel as part of closeAllChannels");
+            },
+            true // also close backend resources immediately
+        );
+    }
     impl_->channels.clear();
 }
 

--- a/nui-file-explorer/include/nui-file-explorer/file_grid.hpp
+++ b/nui-file-explorer/include/nui-file-explorer/file_grid.hpp
@@ -22,6 +22,7 @@ namespace NuiFileExplorer
             std::unique_ptr<ISideModel> leftModel,
             std::unique_ptr<ISideModel> rightModel
         );
+        FileGrid(SideSettings const& leftSettings, std::unique_ptr<ISideModel> leftModel);
         ~FileGrid();
         FileGrid(const FileGrid&) = delete;
         FileGrid& operator=(const FileGrid&) = delete;
@@ -46,10 +47,10 @@ namespace NuiFileExplorer
         void onError(std::function<void(std::string const&)> const& callback);
 
         Side& leftSide();
-        Side& rightSide();
+        Side* rightSide();
 
         ISideModel& leftModel();
-        ISideModel& rightModel();
+        ISideModel* rightModel();
 
         /**
          * @brief Only visually, does not change what the methods leftSide and rightSide return.

--- a/nui-file-explorer/include/nui-file-explorer/side.hpp
+++ b/nui-file-explorer/include/nui-file-explorer/side.hpp
@@ -37,7 +37,13 @@ namespace NuiFileExplorer
         Side(Side&&);
         Side& operator=(Side&&);
 
-        void initialize(Side& otherSide);
+        /**
+         * @brief Initialize passing a pointer to the other side, so that they can interact with each other if needed.
+         *
+         * @param otherSide Other side of the file grid. Its optionally can be nullptr if the file grid only has one
+         * side.
+         */
+        void initialize(Side* otherSide);
 
         ISideModel& model();
 

--- a/nui-file-explorer/include/nui-file-explorer/side/flavor_implementation.hpp
+++ b/nui-file-explorer/include/nui-file-explorer/side/flavor_implementation.hpp
@@ -12,7 +12,7 @@ namespace NuiFileExplorer
     class FlavorImplementation
     {
       public:
-        FlavorImplementation(Side& side, Side& otherSide);
+        FlavorImplementation(Side& side, Side* otherSide);
         virtual ~FlavorImplementation() = default;
 
         virtual Nui::ElementRenderer operator()() = 0;
@@ -21,7 +21,7 @@ namespace NuiFileExplorer
 
       protected:
         SideImplementation& impl() const;
-        SideImplementation& otherImpl() const;
+        SideImplementation* otherImpl() const;
         Side* side_;
         Side* otherSide_;
         Nui::Attribute allowDrop = Nui::Attributes::EventFactory{"dragover"} = [](Nui::WebApi::DragEvent event)

--- a/nui-file-explorer/include/nui-file-explorer/side/icon_flavor.hpp
+++ b/nui-file-explorer/include/nui-file-explorer/side/icon_flavor.hpp
@@ -21,7 +21,7 @@ namespace NuiFileExplorer
       public:
         static constexpr std::chrono::milliseconds boxDragMinimumTimeToDifferentiateClick{150};
 
-        IconFlavor(Side& impl, Side& otherSide);
+        IconFlavor(Side& impl, Side* otherSide);
         ~IconFlavor();
         IconFlavor(const IconFlavor&) = delete;
         IconFlavor& operator=(const IconFlavor&) = delete;

--- a/nui-file-explorer/include/nui-file-explorer/side/table_flavor.hpp
+++ b/nui-file-explorer/include/nui-file-explorer/side/table_flavor.hpp
@@ -18,7 +18,7 @@ namespace NuiFileExplorer
     class TableFlavor : public FlavorImplementation
     {
       public:
-        TableFlavor(Side& impl, Side& otherSide);
+        TableFlavor(Side& impl, Side* otherSide);
         ~TableFlavor();
         Nui::ElementRenderer operator()() override;
 

--- a/nui-file-explorer/source/nui-file-explorer/file_grid.cpp
+++ b/nui-file-explorer/source/nui-file-explorer/file_grid.cpp
@@ -15,7 +15,7 @@ namespace NuiFileExplorer
     struct FileGrid::Implementation
     {
         Side leftSide;
-        Side rightSide;
+        std::optional<Side> rightSide;
 
         Nui::Observed<bool> swapSides{false};
         std::function<void(std::string const&)> onError{};
@@ -43,7 +43,12 @@ namespace NuiFileExplorer
             std::unique_ptr<ISideModel> rightModel
         )
             : leftSide{leftSettings, std::move(leftModel)}
-            , rightSide{rightSettings, std::move(rightModel)}
+            , rightSide{std::make_optional<Side>(rightSettings, std::move(rightModel))}
+        {}
+
+        Implementation(SideSettings const& leftSettings, std::unique_ptr<ISideModel> leftModel)
+            : leftSide{leftSettings, std::move(leftModel)}
+            , rightSide{std::nullopt}
         {}
     };
 
@@ -57,8 +62,13 @@ namespace NuiFileExplorer
               std::make_unique<Implementation>(leftSettings, std::move(leftModel), rightSettings, std::move(rightModel))
           )
     {
-        impl_->leftSide.initialize(impl_->rightSide);
-        impl_->rightSide.initialize(impl_->leftSide);
+        impl_->leftSide.initialize(&impl_->rightSide.value());
+        impl_->rightSide->initialize(&impl_->leftSide);
+    }
+    FileGrid::FileGrid(SideSettings const& leftSettings, std::unique_ptr<ISideModel> leftModel)
+        : impl_(std::make_unique<Implementation>(leftSettings, std::move(leftModel)))
+    {
+        impl_->leftSide.initialize(nullptr);
     }
     FileGrid::~FileGrid()
     {
@@ -75,9 +85,9 @@ namespace NuiFileExplorer
     {
         return impl_->leftSide;
     }
-    Side& FileGrid::rightSide()
+    Side* FileGrid::rightSide()
     {
-        return impl_->rightSide;
+        return impl_->rightSide ? &impl_->rightSide.value() : nullptr;
     }
 
     void FileGrid::onError(std::function<void(std::string const&)> const& callback)
@@ -88,13 +98,15 @@ namespace NuiFileExplorer
     void FileGrid::onUneventfulClick()
     {
         impl_->leftSide.onUneventfulClick();
-        impl_->rightSide.onUneventfulClick();
+        if (impl_->rightSide)
+            impl_->rightSide->onUneventfulClick();
     }
 
     void FileGrid::closeMenus()
     {
         impl_->leftSide.closeMenus();
-        impl_->rightSide.closeMenus();
+        if (impl_->rightSide)
+            impl_->rightSide->closeMenus();
     }
 
     void FileGrid::swapSides(bool doSwap)
@@ -107,9 +119,9 @@ namespace NuiFileExplorer
     {
         return impl_->leftSide.model();
     }
-    ISideModel& FileGrid::rightModel()
+    ISideModel* FileGrid::rightModel()
     {
-        return impl_->rightSide.model();
+        return impl_->rightSide ? &impl_->rightSide->model() : nullptr;
     }
 
     Nui::ElementRenderer FileGrid::operator()(std::vector<Nui::Attribute>&& attributes)
@@ -142,7 +154,7 @@ namespace NuiFileExplorer
             observe(impl_->swapSides),
             [this]() -> Nui::ElementRenderer {
                 auto* left = &impl_->leftSide;
-                auto* right = &impl_->rightSide;
+                auto* right = impl_->rightSide ? &impl_->rightSide.value() : nullptr;
 
                 if (impl_->swapSides.value())
                     std::swap(left, right);
@@ -154,7 +166,7 @@ namespace NuiFileExplorer
                     }
                 }(
                     (*left)(),
-                    (*right)(),
+                    right ? (*right)() : Nui::nil(),
                     div{
                         class_ = "nui-file-grid-divider",
                         reference = [this](std::weak_ptr<Nui::Dom::BasicElement> elem) {

--- a/nui-file-explorer/source/nui-file-explorer/file_grid.cpp
+++ b/nui-file-explorer/source/nui-file-explorer/file_grid.cpp
@@ -165,7 +165,7 @@ namespace NuiFileExplorer
                         if (impl_->rightSide)
                             return "grid-template-columns: 1fr 1fr";
                         return "grid-template-columns: 1fr";
-                    },
+                    }(),
                     reference = [this](std::weak_ptr<Nui::Dom::BasicElement> elem) {
                         impl_->grid = elem;
                     }

--- a/nui-file-explorer/source/nui-file-explorer/file_grid.cpp
+++ b/nui-file-explorer/source/nui-file-explorer/file_grid.cpp
@@ -161,19 +161,24 @@ namespace NuiFileExplorer
 
                 return div{
                     class_ = "nui-file-grid-content",
+                    style = [this](){
+                        if (impl_->rightSide)
+                            return "grid-template-columns: 1fr 1fr";
+                        return "grid-template-columns: 1fr";
+                    },
                     reference = [this](std::weak_ptr<Nui::Dom::BasicElement> elem) {
                         impl_->grid = elem;
                     }
                 }(
                     (*left)(),
                     right ? (*right)() : Nui::nil(),
-                    div{
+                    right ? div{
                         class_ = "nui-file-grid-divider",
                         reference = [this](std::weak_ptr<Nui::Dom::BasicElement> elem) {
                             impl_->divider = elem;
                         }
-                    }(),
-                    div{
+                    }() : Nui::nil(),
+                    right ? div{
                         class_ = "nui-file-grid-grabber",
                         reference = [this](std::weak_ptr<Nui::Dom::BasicElement> elem) {
                             impl_->grabber = elem;
@@ -243,7 +248,7 @@ namespace NuiFileExplorer
                         !("mousedown"_event = [this](Nui::WebApi::MouseEvent) {
                             impl_->dragging = true;
                         })
-                    }()
+                    }() : Nui::nil()
                 );
             }
         );

--- a/nui-file-explorer/source/nui-file-explorer/side.cpp
+++ b/nui-file-explorer/source/nui-file-explorer/side.cpp
@@ -58,11 +58,11 @@ namespace NuiFileExplorer
         , iconFlavor_{}
         , tableFlavor_{}
     {}
-    void Side::initialize(Side& otherSide)
+    void Side::initialize(Side* otherSide)
     {
         iconFlavor_ = std::make_unique<IconFlavor>(*this, otherSide);
         tableFlavor_ = std::make_unique<TableFlavor>(*this, otherSide);
-        impl_->otherSide = &otherSide;
+        impl_->otherSide = otherSide;
     }
     Side::~Side() = default;
     Side::Side(Side&&) = default;

--- a/nui-file-explorer/source/nui-file-explorer/side/flavor_implementation.cpp
+++ b/nui-file-explorer/source/nui-file-explorer/side/flavor_implementation.cpp
@@ -10,17 +10,17 @@
 
 namespace NuiFileExplorer
 {
-    FlavorImplementation::FlavorImplementation(Side& side, Side& otherSide)
+    FlavorImplementation::FlavorImplementation(Side& side, Side* otherSide)
         : side_{&side}
-        , otherSide_{&otherSide}
+        , otherSide_{otherSide}
     {}
     SideImplementation& FlavorImplementation::impl() const
     {
         return *side_->impl_;
     }
-    SideImplementation& FlavorImplementation::otherImpl() const
+    SideImplementation* FlavorImplementation::otherImpl() const
     {
-        return *otherSide_->impl_;
+        return otherSide_ ? &*otherSide_->impl_ : nullptr;
     }
     void FlavorImplementation::onDrop(Nui::WebApi::DragEvent event, std::optional<Item> const& droppedOnItem)
     {
@@ -44,11 +44,14 @@ namespace NuiFileExplorer
                 return;
             }
             Nui::WebApi::Console::log("External items dropped: ", eventExtracted->externDroppedItems->size());
-            otherSide_->model().onDropExternal(
-                *eventExtracted->externDroppedItems,
-                eventExtracted->internalDropSubdir,
-                eventExtracted->issueWebkitWarning
-            );
+            if (otherImpl())
+            {
+                otherSide_->model().onDropExternal(
+                    *eventExtracted->externDroppedItems,
+                    eventExtracted->internalDropSubdir,
+                    eventExtracted->issueWebkitWarning
+                );
+            }
             return;
         }
 
@@ -57,9 +60,12 @@ namespace NuiFileExplorer
             if (side_->model().isLeft() != *eventExtracted->isInternalDropFromLeftSide)
             {
                 // its a transfer!
-                otherSide_->model().onTransfer(
-                    otherImpl().selectionManager.selectedItems(), eventExtracted->internalDropSubdir
-                );
+                if (otherImpl())
+                {
+                    otherSide_->model().onTransfer(
+                        otherImpl()->selectionManager.selectedItems(), eventExtracted->internalDropSubdir
+                    );
+                }
             }
             else
             {

--- a/nui-file-explorer/source/nui-file-explorer/side/icon_flavor.cpp
+++ b/nui-file-explorer/source/nui-file-explorer/side/icon_flavor.cpp
@@ -14,7 +14,7 @@ using namespace std::chrono_literals;
 
 namespace NuiFileExplorer
 {
-    IconFlavor::IconFlavor(Side& side, Side& otherSide)
+    IconFlavor::IconFlavor(Side& side, Side* otherSide)
         : FlavorImplementation{side, otherSide}
     {}
 

--- a/nui-file-explorer/source/nui-file-explorer/side/table_flavor.cpp
+++ b/nui-file-explorer/source/nui-file-explorer/side/table_flavor.cpp
@@ -9,7 +9,7 @@
 
 namespace NuiFileExplorer
 {
-    TableFlavor::TableFlavor(Side& side, Side& otherSide)
+    TableFlavor::TableFlavor(Side& side, Side* otherSide)
         : FlavorImplementation{side, otherSide}
         , columnPixelWidths_{std::vector<std::optional<int>>(columnCount, std::nullopt)}
         , lastContainerWidth_{0.0}

--- a/nui-file-explorer/styles/file_grid.css
+++ b/nui-file-explorer/styles/file_grid.css
@@ -44,7 +44,6 @@
     width: 100%;
     height: 100%;
     display: grid;
-    grid-template-columns: 1fr 1fr;
     grid-template-rows: minmax(0, 1fr);
 }
 

--- a/static/source/content_panel_manager.ts
+++ b/static/source/content_panel_manager.ts
@@ -341,6 +341,23 @@ class ContentPanelManager {
         return undefined;
     }
 
+    renameTerminalById = (panelId: string, channelId: ChannelId, title: string) => {
+        const dock = this.getDockPanelById(panelId);
+        if (!dock) {
+            console.error(`renameTerminalById: no dock panel found for id ${panelId}`);
+            return;
+        }
+        for (const widget of dock.widgets()) {
+            const channelElement = widget.node.querySelector(`.terminal-channel[data-channelid="${channelId}"]`);
+            if (channelElement) {
+                widget.title.label = title;
+                widget.title.caption = title;
+                return;
+            }
+        }
+        console.error(`renameTerminalById: could not find terminal widget with channel id ${channelId}`);
+    }
+
     closeTerminalByNode = (panelId: string, node: HTMLElement) => {
         const dock = this.getDockPanelById(panelId);
         if (!dock) {

--- a/static/source/content_panel_manager.ts
+++ b/static/source/content_panel_manager.ts
@@ -18,6 +18,7 @@ import {
 interface addPanelArguments {
     host: HTMLElement;
     id: string;
+    engineType: string;
     layoutString: string;
     terminalFactory: () => HTMLElement;
     terminalDelete: (channelId: ChannelId | undefined) => any;
@@ -97,19 +98,21 @@ class ContentPanelManager {
         this.lastAddRequest = undefined;
     }
 
-    private makeDefaultDock(id: string): DockPanel {
+    private makeDefaultDock(id: string, engineType: string): DockPanel {
         let term = new Terminal('Terminal', this.terminalFactory, this.terminalDelete);
         let explorer = new FileExplorer('FileExplorer', this.fileExplorerFactory, this.fileExplorerDelete);
-        let queue = new OperationQueue('OperationQueue', this.operationQueueFactory, this.operationQueueDelete);
-        let fileTracking = new FileTracking('File Tracking', this.fileTrackingFactory, this.fileTrackingDelete);
 
         let dock = new DockPanel({
             addButtonEnabled: true,
         });
         dock.addWidget(term);
         dock.addWidget(explorer, { mode: 'split-right', ref: term });
-        dock.addWidget(queue, { mode: "split-bottom", ref: term });
-        dock.addWidget(fileTracking, { mode: "tab-after", ref: queue });
+        if (engineType == 'ssh') {
+            let queue = new OperationQueue('OperationQueue', this.operationQueueFactory, this.operationQueueDelete);
+            let fileTracking = new FileTracking('File Tracking', this.fileTrackingFactory, this.fileTrackingDelete);
+            dock.addWidget(queue, { mode: "split-bottom", ref: term });
+            dock.addWidget(fileTracking, { mode: "tab-after", ref: queue });
+        }
         dock.id = 'dock_' + id;
         this.modifyDefaultLayout(dock);
 
@@ -266,7 +269,7 @@ class ContentPanelManager {
 
         let dock: DockPanel;
         if (layoutString === "" || layoutString === undefined || layoutString === null) {
-            dock = this.makeDefaultDock(id);
+            dock = this.makeDefaultDock(id, args.engineType);
         } else {
             dock = this.makeDockFromLayout(id, layoutString);
         }


### PR DESCRIPTION
- Local Session now displays a file explorer with local files.
- Operation Queue and File Tracking has been disabled on local sessions
- Local session process and pid are now displayed on the session tab and each terminal tab.
- Local session tabs close on process exit.
- Local session tabs close ends the process.