### PR TITLE
Settings restart warning & Reorder Operations

### DIFF
--- a/backend/include/backend/sftp/operation_queue.hpp
+++ b/backend/include/backend/sftp/operation_queue.hpp
@@ -49,6 +49,24 @@ class OperationQueue
     void cancel(Ids::OperationId id);
 
     /**
+     * @brief Move @p operationId within the regular `operations_` queue to
+     *        the absolute index @p newIndex.  Dispatched through the strand
+     *        so it cannot interleave with `work()`; the running op (deque
+     *        front) is therefore safely repositioned.
+     *
+     *        No-ops silently when:
+     *          - the queue is not paused (the frontend must pause first;
+     *            this is the safety belt for races against unpause),
+     *          - the id refers to a priority op (priority queue is not
+     *            user-reorderable in this UI),
+     *          - the id is no longer in the queue (op completed meanwhile).
+     *
+     *        On a successful move emits `onOperationsReordered` so the
+     *        frontend can reflect the new order without optimistic updates.
+     */
+    void moveOperation(Ids::OperationId operationId, std::size_t newIndex);
+
+    /**
      * @brief Returns true if it should be called without delay again.
      *
      * @return true

--- a/backend/source/backend/CMakeLists.txt
+++ b/backend/source/backend/CMakeLists.txt
@@ -125,9 +125,7 @@ if (NOT OMIT_FRONTEND_BUILD)
             ${CMAKE_SOURCE_DIR}
         DISABLE_BIN2HPP
         CMAKE_OPTIONS
-            # I recommend to work with a release build by default because debug builds get big fast.
-            -DCMAKE_BUILD_TYPE=Debug
-            #-DCMAKE_BUILD_TYPE=Release
+            -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
             -DNUI_FETCH_TRAITS=Off
             -DNUI_FETCH_BOOST_DESCRIBE=ON
             -DNUI_FETCH_BOOST_MP11=ON

--- a/backend/source/backend/sftp/operation_queue.cpp
+++ b/backend/source/backend/sftp/operation_queue.cpp
@@ -6,6 +6,7 @@
 #include <shared_data/file_operations/sync_scan_result.hpp>
 #include <shared_data/file_operations/operation_added.hpp>
 #include <shared_data/file_operations/operation_completed.hpp>
+#include <shared_data/file_operations/operations_reordered.hpp>
 #include <shared_data/error_or_success.hpp>
 #include <shared_data/is_paused.hpp>
 
@@ -303,6 +304,100 @@ void OperationQueue::cancel(Ids::OperationId id)
             const auto erasedFromRegular = std::erase_if(self->operations_, cancelPredicate);
             if (erasedFromRegular == 0)
                 std::erase_if(self->priorityOperations_, cancelPredicate);
+        }
+    );
+}
+
+void OperationQueue::moveOperation(Ids::OperationId operationId, std::size_t newIndex)
+{
+    within_strand_do(
+        [weak = weak_from_this(), operationId = std::move(operationId), newIndex]() mutable
+        {
+            auto self = weak.lock();
+            if (!self)
+                return;
+
+            // Pessimistic resolution: every exit path emits onOperationsReordered
+            // so the frontend always gets a definitive "this move was/was not
+            // applied" — never silently dropped. The frontend's listener relies
+            // on this to apply or discard the user's intended reorder.
+            auto emitResolution = [&self, &operationId](std::size_t resolvedIndex, bool applied)
+            {
+                self->hub_->callRemote(
+                    self->rpcName("onOperationsReordered"),
+                    SharedData::OperationsReordered{
+                        .operationId = operationId,
+                        .newIndex = static_cast<std::int32_t>(resolvedIndex),
+                        .applied = applied,
+                    }
+                );
+            };
+
+            // Pause is the only safe window: while running, work() can be
+            // mid-batch with raw pointers into the deque (see workQueue()),
+            // and reordering would alter the indices it iterates.
+            if (!self->paused_)
+            {
+                Log::warn(
+                    "OperationQueue::moveOperation refused — queue not paused (op '{}')",
+                    operationId.value()
+                );
+                return emitResolution(newIndex, false);
+            }
+
+            // Priority queue is intentionally not user-reorderable.
+            for (auto const& [pid, _op] : self->priorityOperations_)
+            {
+                if (pid == operationId)
+                {
+                    Log::warn(
+                        "OperationQueue::moveOperation refused — '{}' is a priority op",
+                        operationId.value()
+                    );
+                    return emitResolution(newIndex, false);
+                }
+            }
+
+            auto& queue = self->operations_;
+            std::size_t oldIndex = 0;
+            bool found = false;
+            for (std::size_t idx = 0; idx < queue.size(); ++idx)
+            {
+                if (queue[idx].first == operationId)
+                {
+                    oldIndex = idx;
+                    found = true;
+                    break;
+                }
+            }
+            if (!found)
+            {
+                // Op completed/canceled between click and strand tick — silent
+                // resolution; the frontend already removed the card via
+                // onOperationCompleted, so applied=false is purely informational.
+                return emitResolution(newIndex, false);
+            }
+
+            if (queue.empty())
+                return emitResolution(newIndex, false);
+            if (newIndex >= queue.size())
+                newIndex = queue.size() - 1;
+            if (oldIndex == newIndex)
+                return emitResolution(newIndex, false);
+
+            auto entry = std::move(queue[oldIndex]);
+            queue.erase(queue.begin() + static_cast<std::ptrdiff_t>(oldIndex));
+            queue.insert(queue.begin() + static_cast<std::ptrdiff_t>(newIndex), std::move(entry));
+
+            Log::info(
+                "OperationQueue::moveOperation '{}' from {} to {} (queue size {})",
+                operationId.value(),
+                oldIndex,
+                newIndex,
+                queue.size()
+            );
+
+            emitResolution(newIndex, true);
         }
     );
 }
@@ -1537,6 +1632,25 @@ void OperationQueue::registerRpc()
                     return reply(SharedData::error("OperationQueue no longer exists"));
 
                 self->cancelAll();
+                return reply(SharedData::success());
+            }
+        );
+
+    on(rpcName("moveOperation"))
+        .perform(
+            [weak = weak_from_this()](
+                RpcHelper::RpcOnce&& reply, Ids::OperationId operationId, std::int32_t newIndex
+            )
+            {
+                auto self = weak.lock();
+                if (!self)
+                    return reply(SharedData::error("OperationQueue no longer exists"));
+
+                // Reply immediately to release the frontend's backchannel temp
+                // RPC name. The actual move + onOperationsReordered broadcast
+                // happen asynchronously inside moveOperation's strand task.
+                const auto clamped = newIndex < 0 ? std::size_t{0} : static_cast<std::size_t>(newIndex);
+                self->moveOperation(std::move(operationId), clamped);
                 return reply(SharedData::success());
             }
         );

--- a/frontend/include/frontend/observed_random_access_map.hpp
+++ b/frontend/include/frontend/observed_random_access_map.hpp
@@ -96,6 +96,58 @@ class ObservedRandomAccessMap
         observedValues_.erase(dequeIt);
     }
 
+    /**
+     * @brief Move the entry for @p key to position @p newIndex in the
+     *        underlying deque.  No-op when @p key is absent or already at
+     *        @p newIndex.  @p newIndex is clamped to `[0, size()-1]`.
+     *
+     *        Issued as a single `Nui::Observed::erase()` + `insert()` pair so
+     *        only the moved card's DOM subtree is rebuilt — the in-between
+     *        cards stay mounted.  The owning `shared_ptr<ValueT>` is
+     *        preserved across the move, so the card's internal `Nui::Observed`
+     *        state (progress bars, completion timers, dialog handles) is
+     *        fully retained.
+     */
+    void move(KeyT const& key, std::size_t newIndex)
+    {
+        auto mapIt = keyToPointerMap_.find(key);
+        if (mapIt == keyToPointerMap_.end())
+            return;
+
+        auto const& staticDeque = observedValues_.value();
+        if (staticDeque.empty())
+            return;
+
+        ValueT* ptr = mapIt->second;
+        std::size_t oldIndex = 0;
+        bool found = false;
+        for (std::size_t idx = 0; idx < staticDeque.size(); ++idx)
+        {
+            if (staticDeque[idx].get() == ptr)
+            {
+                oldIndex = idx;
+                found = true;
+                break;
+            }
+        }
+        if (!found)
+            return;
+
+        if (newIndex >= staticDeque.size())
+            newIndex = staticDeque.size() - 1;
+        if (oldIndex == newIndex)
+            return;
+
+        // Shared_ptr keeps the entry alive across the erase; insert moves it
+        // back into the deque at the new position.  The intervening cards see
+        // only their grid-row index shift — no DOM teardown.
+        auto entry = observedValues_.value()[oldIndex];
+        observedValues_.erase(observedValues_.begin() + static_cast<std::ptrdiff_t>(oldIndex));
+        observedValues_.insert(
+            observedValues_.begin() + static_cast<std::ptrdiff_t>(newIndex), std::move(entry)
+        );
+    }
+
     Nui::Observed<std::deque<std::shared_ptr<ValueT>>>& observedValues()
     {
         return observedValues_;

--- a/frontend/include/frontend/session_components/operation_queue.hpp
+++ b/frontend/include/frontend/session_components/operation_queue.hpp
@@ -17,6 +17,7 @@
 #include <shared_data/file_operations/operation_error.hpp>
 #include <shared_data/file_operations/operation_state.hpp>
 #include <shared_data/file_operations/operation_completed.hpp>
+#include <shared_data/file_operations/operations_reordered.hpp>
 #include <shared_data/file_operations/bulk_add_request.hpp>
 #include <shared_data/is_paused.hpp>
 #include <shared_data/error_or_success.hpp>
@@ -252,6 +253,16 @@ class OperationQueue
     void onScanProgress(SharedData::ScanProgress const& progress);
     void onOperationCompleted(Nui::val val);
     void onIsPaused(SharedData::ErrorOrSuccess<SharedData::IsPaused> const& result);
+    void onOperationsReordered(SharedData::OperationsReordered const& evt);
+    void requestMoveOperation(Ids::OperationId const& opId, std::size_t newIndex);
+
+    /**
+     * @brief Build the live regular-queue list element, attaching delegated
+     *        drag handlers (one set of dragstart/dragover/dragleave/drop on
+     *        the list container) so per-card cost stays O(1).  Modeled on
+     *        icon_flavor.cpp / flavor_implementation.cpp's drag delegation.
+     */
+    Nui::ElementRenderer makeRegularLiveList();
 
   private:
     struct Implementation;

--- a/frontend/include/frontend/session_components/operation_queue/operation_card.hpp
+++ b/frontend/include/frontend/session_components/operation_queue/operation_card.hpp
@@ -22,7 +22,9 @@
 #include <ui5-sap-icons/icons/delete.hpp>
 #include <ui5-sap-icons/icons/refresh.hpp>
 #include <ui5-sap-icons/icons/edit.hpp>
+#include <ui5-sap-icons/icons/high-priority.hpp>
 
+#include <utility/language.hpp>
 #include <utility/convert_naming_convention.hpp>
 #include <utility/visit_overloaded.hpp>
 #include <utility/format_bytes.hpp>
@@ -129,7 +131,27 @@ class OperationCard : public OperationCardInterface
                         return "";
                 }(), !isSubgridOperation ? "opq-card-gridspan": "opq-card-subgrid");
             }),
+            // Stable per-card identity: lets the queue's delegated drag handlers
+            // resolve which card a dragstart/drop targets via closest("[data-op-id]").
+            "data-op-id"_attr = operationId_.value(),
+            // Always draggable; the dragstart handler at the list level rejects
+            // non-paused drags via preventDefault — keeps gating in one place.
+            "draggable"_attr = "true",
         }(
+            // Kick-to-top button. Visibility gated purely by CSS using
+            // .operation-queue[data-paused] selector — no per-card observed
+            // state, so cost stays O(1) per card no matter the queue length.
+            div{
+                class_ = "op-kick-up",
+                onClick = [this](Nui::val event){
+                    // Stop the click from bubbling to the card root (which is
+                    // also a drag source / potential parent click target).
+                    event.call<void>("stopPropagation");
+                    if (kickToTopHandler_)
+                        kickToTopHandler_();
+                },
+                Nui::Attributes::title = language->get("operationQueue", "kickToTopTitle"),
+            }(Ui5Icons::high_priority()),
             // Icon
             div{}(
                 observe(state_),
@@ -320,6 +342,11 @@ class OperationCard : public OperationCardInterface
         failedEntries_ = std::move(entries);
     }
 
+    void setKickToTopHandler(std::function<void()> handler) override
+    {
+        kickToTopHandler_ = std::move(handler);
+    }
+
   protected:
     mutable std::weak_ptr<Nui::Dom::BasicElement> cardElement_;
     std::chrono::steady_clock::time_point startTime_{std::chrono::steady_clock::now()};
@@ -333,4 +360,5 @@ class OperationCard : public OperationCardInterface
     std::shared_ptr<Nui::Observed<bool>> doDeletionCountdown_;
     std::function<void()> onCompleteAction_;
     Nui::Observed<std::vector<std::pair<std::filesystem::path, SharedData::OperationError>>> failedEntries_;
+    std::function<void()> kickToTopHandler_;
 };

--- a/frontend/include/frontend/session_components/operation_queue/operation_card_interface.hpp
+++ b/frontend/include/frontend/session_components/operation_queue/operation_card_interface.hpp
@@ -18,6 +18,7 @@
 #include <nui/frontend/element_renderer.hpp>
 
 #include <chrono>
+#include <functional>
 #include <optional>
 
 class OperationCardInterface
@@ -35,6 +36,16 @@ class OperationCardInterface
     virtual Nui::ElementRenderer operator()() const = 0;
     virtual void setError(SharedData::OperationError const& error) = 0;
     virtual void failedEntries(std::vector<std::pair<std::filesystem::path, SharedData::OperationError>> entries) = 0;
+
+    /**
+     * @brief Install a click handler for the kick-to-top affordance.  The
+     *        OperationQueue calls this after the card is constructed so the
+     *        button can directly trigger a `moveOperation(id, 0)` RPC
+     *        without coupling the card to the queue.  Empty handler =
+     *        button is rendered but is a no-op (and is hidden by CSS unless
+     *        the queue root has `data-paused`).
+     */
+    virtual void setKickToTopHandler(std::function<void()> handler) = 0;
 
     /**
      * @brief Describe this operation so it can be re-enqueued (with

--- a/frontend/include/frontend/settings/atomic_setting/list_setting.hpp
+++ b/frontend/include/frontend/settings/atomic_setting/list_setting.hpp
@@ -80,8 +80,10 @@ class ListSetting : public Setting<Disengageable, ListTypeT<std::string>>
         // clang-format off
         return div{}(
             SettingBase::label(std::forward<decltype(labelText)>(labelText)),
-            (*table_)(
-                {observeEngagedToBool(disabled)}
+            div{class_ = "setting-table-container"}(
+                (*table_)(
+                    {observeEngagedToBool(disabled)}
+                )
             ),
             reset(),
             help()

--- a/frontend/include/frontend/settings/atomic_setting/map_setting.hpp
+++ b/frontend/include/frontend/settings/atomic_setting/map_setting.hpp
@@ -146,8 +146,10 @@ class MapSetting : public Setting<Disengageable, std::map<std::string, std::stri
         // clang-format off
         return div{}(
             SettingBase::label(std::forward<decltype(labelText)>(labelText)),
-            (*table_)(
-                {observeEngagedToBool(disabled)}
+            div{class_ = "setting-table-container"}(
+                (*table_)(
+                    {observeEngagedToBool(disabled)}
+                )
             ),
             reset(),
             help()

--- a/frontend/include/frontend/settings/log_options.hpp
+++ b/frontend/include/frontend/settings/log_options.hpp
@@ -7,6 +7,8 @@
 
 #include <persistence/state/log_options.hpp>
 
+#include <nui/event_system/listen.hpp>
+
 #include <functional>
 
 struct LogOptions : public GroupKeys
@@ -24,4 +26,5 @@ struct LogOptions : public GroupKeys
 
   private:
     std::function<void()> onChange_;
+    Nui::ListenRemover<Nui::Observed<Log::Level>> logLevelListener_;
 };

--- a/frontend/source/frontend/file_explorer/remote_side_model.cpp
+++ b/frontend/source/frontend/file_explorer/remote_side_model.cpp
@@ -1199,8 +1199,16 @@ void RemoteSideModel::onFileTrackingInstanceCreated(
 
     NuiFileExplorer::Item remoteItem = item;
     remoteItem.path = remotePath;
+    remoteItem.fullPath = remotePath;
     NuiFileExplorer::Item localItem = item;
     localItem.path = localPath;
+    // FileEngine::addDownload prefers `fullPath` over `path` when serializing
+    // the destination. Without overwriting it here, `localItem.fullPath` would
+    // still hold the source item's *remote* fullPath (carried over by the
+    // copy-construction above), and the backend would receive the remote path
+    // as both source and destination — making it try to write
+    // `<remotePath>.filepart` next to the remote file (permission denied).
+    localItem.fullPath = localPath;
 
     operationQueue_->enqueueDownload(
         remoteItem,

--- a/frontend/source/frontend/session_components/operation_queue.cpp
+++ b/frontend/source/frontend/session_components/operation_queue.cpp
@@ -18,6 +18,7 @@
 #include <nui/frontend/attributes.hpp>
 #include <nui/frontend/elements.hpp>
 #include <nui/frontend/api/keyboard_event.hpp>
+#include <nui/frontend/api/drag_event.hpp>
 #include <nui/frontend/api/timer.hpp>
 #include <nui/frontend/svg.hpp>
 #include <nui/frontend/api/json.hpp>
@@ -76,7 +77,7 @@ struct OperationQueue::Implementation
     // Pagination / navigation state.
     Nui::Observed<int> pageCount{1};
     Nui::Observed<int> currentPage{0}; // pageCount-1 is the live page.
-    Nui::Observed<int> activeTab{0}; // 0 = Queue (live + history), 1 = Failed
+    Nui::Observed<int> activeTab{0}; // 0 = Queue (live + history), 1 = Failed, 2 = Priority
     // True until the user explicitly clicks a non-live history page. While
     // true, the live page follows overflow growth so the user is not yanked
     // into a stale history page when a new eviction bumps pageCount.
@@ -102,6 +103,37 @@ struct OperationQueue::Implementation
     Nui::Observed<bool> minimizedSyncVisible{false};
     Nui::Observed<int> minimizedSyncShine{0};
     std::function<void()> minimizedSyncRestore{};
+
+    // Drag-state (regular-queue reorder).  Held outside any per-card observed
+    // so the hover indicator costs zero per-card overhead and avoids extra
+    // re-renders.  `currentHoverEl` is the DOM element the drop indicator is
+    // currently attached to via direct classList manipulation (mirroring
+    // icon_flavor's setHoverItem pattern).
+    Nui::val currentHoverEl{Nui::val::null()};
+    bool currentHoverBelow{false};
+
+    void clearDragHover()
+    {
+        if (currentHoverEl.isNull() || currentHoverEl.isUndefined())
+            return;
+        auto cl = currentHoverEl["classList"];
+        cl.call<void>("remove", std::string{"opq-drop-above"});
+        cl.call<void>("remove", std::string{"opq-drop-below"});
+        currentHoverEl = Nui::val::null();
+    }
+
+    void setDragHover(Nui::val targetEl, bool below)
+    {
+        if (!currentHoverEl.isNull() && !currentHoverEl.isUndefined() &&
+            currentHoverEl.equals(targetEl) && currentHoverBelow == below)
+            return;
+        clearDragHover();
+        if (targetEl.isNull() || targetEl.isUndefined())
+            return;
+        targetEl["classList"].call<void>("add", std::string{below ? "opq-drop-below" : "opq-drop-above"});
+        currentHoverEl = std::move(targetEl);
+        currentHoverBelow = below;
+    }
 
     DisplayedOperation* findOperation(Ids::OperationId const& id)
     {
@@ -540,6 +572,16 @@ void OperationQueue::activate(std::shared_ptr<FileEngine> fileEngine, Ids::Sessi
 
     impl_->onUpdate.push_back(
         Nui::RpcClient::autoRegisterFunction(
+            fmt::format("OperationQueue::{}::onOperationsReordered", impl_->sessionId.value()),
+            [this](SharedData::OperationsReordered const& evt)
+            {
+                onOperationsReordered(evt);
+            }
+        )
+    );
+
+    impl_->onUpdate.push_back(
+        Nui::RpcClient::autoRegisterFunction(
             fmt::format("OperationQueue::{}::onSyncScanResult", impl_->sessionId.value()),
             [this](Nui::val val)
             {
@@ -806,6 +848,17 @@ void OperationQueue::onOperationAdded(SharedData::OperationAdded const& added)
     {
         Log::error("Failed to create operation card for operation id: {}", added.operationId.value());
         return;
+    }
+    // Kick-to-top is meaningful only for the regular queue. Priority cards do
+    // not get a handler — even though the button is rendered, CSS hides it
+    // when the parent is the priority list (see .opq-priority-list rule).
+    if (added.mode != SharedData::OperationMode::PriorityQueued)
+    {
+        card->setKickToTopHandler(
+            [this, opId = added.operationId]() {
+                requestMoveOperation(opId, 0);
+            }
+        );
     }
     Log::info("Inserting operation id: {} into operation queue", added.operationId.value());
     try
@@ -1278,6 +1331,40 @@ void OperationQueue::hideMinimizedSync()
     Nui::globalEventContext.executeActiveEventsImmediately();
 }
 
+void OperationQueue::onOperationsReordered(SharedData::OperationsReordered const& evt)
+{
+    if (!evt.applied)
+    {
+        // Backend refused or no-oped (queue not paused, op completed, priority
+        // op, etc.). Frontend never optimistically reorders, so there is
+        // nothing to roll back; this branch exists so the frontend has a
+        // definitive resolution signal it can hook into later if needed.
+        return;
+    }
+    impl_->operations.move(evt.operationId, static_cast<std::size_t>(evt.newIndex));
+    Nui::globalEventContext.executeActiveEventsImmediately();
+}
+
+void OperationQueue::requestMoveOperation(Ids::OperationId const& opId, std::size_t newIndex)
+{
+    if (!impl_->paused.value())
+    {
+        // Local guard — backend has its own pause check, but failing fast here
+        // avoids a wasted round trip and a refused log on the backend side.
+        return;
+    }
+    Nui::RpcClient::callWithBackChannel(
+        fmt::format("OperationQueue::{}::moveOperation", impl_->sessionId.value()),
+        [opId](SharedData::ErrorOrSuccess<> const& result)
+        {
+            if (!result)
+                Log::error("moveOperation RPC failed for op {}: {}", opId.value(), result.error.value());
+        },
+        opId,
+        static_cast<std::int32_t>(newIndex)
+    );
+}
+
 void OperationQueue::onIsPaused(SharedData::ErrorOrSuccess<SharedData::IsPaused> const& result)
 {
     if (result)
@@ -1383,6 +1470,158 @@ void OperationQueue::changeAutoClean(bool doClean)
     );
 }
 
+Nui::ElementRenderer OperationQueue::makeRegularLiveList()
+{
+    using namespace Nui::Elements;
+    using namespace Nui::Attributes;
+    using Nui::Elements::div;
+
+    // Resolve the card element (and its op id) for an arbitrary event target
+    // by walking up through `closest("[data-op-id]")`.  Mirrors the resolver
+    // in flavor_implementation.cpp:79-88.
+    auto resolveCard = [](Nui::val target) -> std::pair<Nui::val, std::string> {
+        if (target.isNull() || target.isUndefined())
+            return {Nui::val::null(), {}};
+        auto node = target.call<Nui::val>("closest", std::string{"[data-op-id]"});
+        if (node.isNull() || node.isUndefined())
+            return {Nui::val::null(), {}};
+        auto attr = node.call<Nui::val>("getAttribute", std::string{"data-op-id"});
+        if (attr.isNull() || attr.isUndefined())
+            return {Nui::val::null(), {}};
+        return {std::move(node), attr.as<std::string>()};
+    };
+
+    // Look up an op's current index in the live regular queue.  Returns -1
+    // if the op completed/was removed between drag start and drop.
+    auto findIndex = [this](std::string const& opId) -> int {
+        auto const& deque = impl_->operations.observedValues().value();
+        for (std::size_t idx = 0; idx < deque.size(); ++idx)
+        {
+            if (deque[idx]->key().value() == opId)
+                return static_cast<int>(idx);
+        }
+        return -1;
+    };
+
+    return div{
+        // `opq-reorderable` marks this list as the only surface where drag and
+        // kick-to-top are valid.  Failed / Priority / history pages all reuse
+        // .opq-regular-list for their grid layout, but those surfaces must NOT
+        // show the affordance — the CSS gate uses .opq-reorderable to scope it.
+        class_ = "opq-regular-list opq-reorderable",
+        // Delegated drag handlers — one set for the entire list, regardless
+        // of card count.  Each handler resolves the affected card via
+        // resolveCard().  This is the "many items" optimization the user
+        // pointed at in icon_flavor.cpp.
+        "dragstart"_event = [this, resolveCard](Nui::WebApi::DragEvent event) {
+            if (!impl_->paused.value())
+            {
+                event.val().call<void>("preventDefault");
+                return;
+            }
+            auto [el, opId] = resolveCard(event.val()["target"]);
+            if (opId.empty())
+            {
+                event.val().call<void>("preventDefault");
+                return;
+            }
+            auto dt = event.val()["dataTransfer"];
+            if (dt.isNull() || dt.isUndefined())
+                return;
+            dt.call<void>("setData", std::string{"text/plain"}, opId);
+            dt.set("effectAllowed", std::string{"move"});
+            // Visual cue on the dragged card itself (separate from drop target).
+            el["classList"].call<void>("add", std::string{"opq-dragging"});
+        },
+        "dragend"_event = [this, resolveCard](Nui::WebApi::DragEvent event) {
+            // Always clear visuals — fires whether the drop succeeded or not.
+            auto [el, _opId] = resolveCard(event.val()["target"]);
+            if (!el.isNull() && !el.isUndefined())
+                el["classList"].call<void>("remove", std::string{"opq-dragging"});
+            impl_->clearDragHover();
+        },
+        "dragover"_event = [this, resolveCard](Nui::WebApi::DragEvent event) {
+            if (!impl_->paused.value())
+                return;
+            // Always preventDefault on dragover or the drop event will not fire.
+            event.val().call<void>("preventDefault");
+            auto [el, _opId] = resolveCard(event.val()["target"]);
+            if (el.isNull() || el.isUndefined())
+            {
+                impl_->clearDragHover();
+                return;
+            }
+            const auto rect = el.call<Nui::val>("getBoundingClientRect");
+            const auto top = rect["top"].as<double>();
+            const auto height = rect["height"].as<double>();
+            const auto y = event.val()["clientY"].as<double>();
+            const bool below = (y - top) > (height * 0.5);
+            impl_->setDragHover(std::move(el), below);
+        },
+        "dragleave"_event = [this](Nui::WebApi::DragEvent event) {
+            // Only clear when leaving the list container as a whole (not when
+            // moving between cards inside it).  Same guard as
+            // flavor_implementation.cpp:144-153.
+            auto related = event.val()["relatedTarget"];
+            auto current = event.val()["currentTarget"];
+            if (!related.isNull() && !related.isUndefined() &&
+                !current.isNull() && !current.isUndefined() &&
+                current.call<bool>("contains", related))
+            {
+                return;
+            }
+            impl_->clearDragHover();
+        },
+        "drop"_event = [this, resolveCard, findIndex](Nui::WebApi::DragEvent event) {
+            if (!impl_->paused.value())
+                return;
+            event.val().call<void>("preventDefault");
+
+            auto dt = event.val()["dataTransfer"];
+            std::string draggedId;
+            if (!dt.isNull() && !dt.isUndefined())
+            {
+                draggedId = dt.call<Nui::val>("getData", std::string{"text/plain"}).as<std::string>();
+            }
+
+            const bool below = impl_->currentHoverBelow;
+            impl_->clearDragHover();
+
+            if (draggedId.empty())
+                return;
+
+            auto [_el, targetId] = resolveCard(event.val()["target"]);
+            if (targetId.empty() || targetId == draggedId)
+                return;
+
+            const int oldIndex = findIndex(draggedId);
+            const int targetIndex = findIndex(targetId);
+            if (oldIndex < 0 || targetIndex < 0)
+                return;
+
+            // Translate (above|below target) into an absolute desired index.
+            // Compensates for the deque shrinking by one when oldIndex < targetIndex.
+            int newIndex = below ? (targetIndex + 1) : targetIndex;
+            if (oldIndex < newIndex)
+                newIndex -= 1;
+
+            const int size = static_cast<int>(impl_->operations.observedValues().value().size());
+            if (newIndex < 0)
+                newIndex = 0;
+            if (newIndex >= size)
+                newIndex = size - 1;
+            if (newIndex == oldIndex)
+                return;
+
+            requestMoveOperation(Ids::makeOperationId(draggedId), static_cast<std::size_t>(newIndex));
+        },
+    }(
+        impl_->operations.observedValues().map(
+            [](auto, auto const& element) { return (*element)(); }
+        )
+    );
+}
+
 Nui::ElementRenderer OperationQueue::operator()()
 {
     using namespace Nui::Elements;
@@ -1406,6 +1645,15 @@ Nui::ElementRenderer OperationQueue::operator()()
     // clang-format off
     return div{
         class_ = "operation-queue",
+        // Single source of truth for "kick-to-top + drag are active".  Optional
+        // returning nullopt removes the attribute entirely so CSS rules like
+        // `.operation-queue[data-paused] .op-kick-up` only match while paused.
+        // Avoids putting an Observed<bool> on every card.
+        "data-paused"_attr = observe(impl_->paused).generate([this]() -> std::optional<std::string> {
+            if (impl_->paused.value())
+                return std::optional<std::string>{"true"};
+            return std::nullopt;
+        }),
         tabIndex = 0,
         "keydown"_event = [this](Nui::WebApi::KeyboardEvent event) {
             const auto key = event.key();
@@ -1495,7 +1743,10 @@ Nui::ElementRenderer OperationQueue::operator()()
                     .generate(makeSummaryText)
             )
         ),
-        // Tab bar — Queue (live + history via pagination) vs Failed.
+        // Tab bar — Queue (live + history via pagination) vs Failed vs Priority.
+        // Priority lives in its own tab (rather than on top of the live page)
+        // because it's intentionally non-reorderable — keeping it on the same
+        // surface as the drag-reorderable regular queue would be confusing UX.
         div{class_ = "opq-tabs"}(
             div{
                 class_ = observe(impl_->activeTab).generate([this]() {
@@ -1503,6 +1754,13 @@ Nui::ElementRenderer OperationQueue::operator()()
                 }),
                 onClick = [this](Nui::val) { impl_->activeTab = 0; },
             }(span{}(language->getObserved("operationQueue", "tabQueue"))),
+            div{
+                class_ = observe(impl_->activeTab).generate([this]() {
+                    return std::string{"opq-tab"} + (impl_->activeTab.value() == 2 ? " selected" : "");
+                }),
+                onClick = [this](Nui::val) { impl_->activeTab = 2; },
+            }(span{}(language->getObserved("operationQueue", "tabPriority")))
+            ,
             div{
                 class_ = observe(impl_->activeTab).generate([this]() {
                     return std::string{"opq-tab"} + (impl_->activeTab.value() == 1 ? " selected" : "");
@@ -1537,14 +1795,15 @@ Nui::ElementRenderer OperationQueue::operator()()
                 },
             })
         ),
-        // Main content — switches between live page (reactive, preserves
-        // single-insert perf), a static history-page slice, or the Failed tab.
+        // Main content — switches between live regular-queue page, a static
+        // history-page slice, the Failed tab, or the new Priority tab.
         div{
             class_ = "opq-list"
         }(
-            // Only subscribe to tab + paging state here.  `failed` mutations
-            // must NOT tear down the live reactive ranges below, or every new
-            // failure would wipe the live list and re-create all card nodes.
+            // Only subscribe to tab + paging state here.  `failed` and
+            // `priorityOperations` mutations must NOT tear down the live
+            // regular-queue ranges below, or every new addition would wipe
+            // the live list and re-create all card nodes.
             Nui::observe(impl_->activeTab, impl_->currentPage, impl_->pageCount),
             [this]() -> Nui::ElementRenderer
             {
@@ -1561,35 +1820,38 @@ Nui::ElementRenderer OperationQueue::operator()()
                     );
                 }
 
+                if (impl_->activeTab.value() == 2)
+                {
+                    // Priority tab: non-reorderable.  Cards still render with
+                    // the kick-to-top button DOM, but no handler is installed
+                    // (see onOperationAdded) and CSS hides the button on this
+                    // surface via .opq-priority-list .op-kick-up { display:none }.
+                    return div{class_ = "opq-priority-list"}(
+                        Nui::range(impl_->priorityOperations.observedValues()),
+                        [](long long, auto const& element) -> Nui::ElementRenderer {
+                            return (*element)();
+                        }
+                    );
+                }
+
                 const int page = impl_->currentPage.value();
                 const int pageMax = impl_->pageCount.value() - 1;
 
                 if (page >= pageMax)
                 {
-                    // Live page: original reactive markup wrapped in one host
-                    // div with display:contents (see operation_queue.css) so
-                    // priority/regular cards remain direct .opq-list grid
-                    // children.  Re-entering re-establishes the Observed
-                    // subscription so subsequent enqueue/dequeue stays single-diff.
-                    return div{class_ = "opq-live-wrapper"}(
-                        div{class_ = "opq-priority-list"}(
-                            // TODO: Make after element depend on list length > 0
-                            Nui::range(impl_->priorityOperations.observedValues())
-                                .after(div{class_ = "opq-priority-separator"}()),
-                            [](auto, auto const& element) -> Nui::ElementRenderer
-                            {
-                                return (*element)();
-                            }
-                        ),
-                        div{class_ = "opq-regular-list"}(
-                            impl_->operations.observedValues().map(
-                                [](auto, auto const& element) { return (*element)(); }
-                            )
-                        )
-                    );
+                    // Live regular-queue page.  Drag handlers are delegated at
+                    // this list level (not per-card) — see icon_flavor.cpp /
+                    // flavor_implementation.cpp for the same pattern in the
+                    // file explorer.  This keeps DnB cost O(1) regardless of
+                    // queue size.
+                    return makeRegularLiveList();
                 }
 
-                // History page: static slice of evicted cards.
+                // History page: static slice of evicted cards.  Not reorderable;
+                // the .opq-regular-list class still applies but no draggable
+                // attribute is set on history cards' wrapping (the cards
+                // themselves carry draggable=true but the parent has no drag
+                // handler so it fizzles).
                 const int pageSize = std::max(1, impl_->liveQueuePageSize);
                 const int begin = page * pageSize;
                 const int end = std::min(begin + pageSize, static_cast<int>(impl_->history.size()));

--- a/frontend/source/frontend/settings.cpp
+++ b/frontend/source/frontend/settings.cpp
@@ -100,8 +100,50 @@ struct Settings::Implementation
     Nui::Observed<bool> wasInitiallyLoaded{false};
     Nui::Observed<bool> initialLoadDone{false};
 
+    // Tracks whether the user has modified any setting that only takes effect
+    // after an app restart. The baseline is captured each time the settings
+    // dialog opens; listeners on the critical fields flip requiresRestart
+    // whenever the current value diverges from the baseline (and back to
+    // false if the user reverts).
+    struct RestartCriticalBaseline
+    {
+        std::string languageCode;
+        std::string logDirectory;
+        bool disableFileLogging{false};
+        std::optional<std::filesystem::path> temporaryDownloadsDirectory;
+        std::optional<int> concurrency;
+    };
+    Nui::Observed<bool> requiresRestart{false};
+    RestartCriticalBaseline restartBaseline{};
+
     Nui::ListenRemover<decltype(FrontendEvents::settingsOpen)> settingsOpenListener{};
     Nui::ListenRemover<decltype(FrontendEvents::requestedSettingScrollId)> requestedSettingScrollIdListener{};
+
+    void captureRestartBaseline()
+    {
+        restartBaseline = RestartCriticalBaseline{
+            .languageCode = generalSettings.localization.language.value(),
+            .logDirectory = generalSettings.logOptions.logDirectory.value(),
+            .disableFileLogging = generalSettings.logOptions.disableFileLogging.value(),
+            .temporaryDownloadsDirectory =
+                generalSettings.localFilesystemOptions.temporaryDownloadsDirectory.value(),
+            .concurrency = sftpOptions.concurrency.value(),
+        };
+        requiresRestart = false;
+    }
+
+    void recomputeRequiresRestart()
+    {
+        if (applyingToUi)
+            return;
+        requiresRestart =
+            generalSettings.localization.language.value() != restartBaseline.languageCode
+            || generalSettings.logOptions.logDirectory.value() != restartBaseline.logDirectory
+            || generalSettings.logOptions.disableFileLogging.value() != restartBaseline.disableFileLogging
+            || generalSettings.localFilesystemOptions.temporaryDownloadsDirectory.value()
+                != restartBaseline.temporaryDownloadsDirectory
+            || sftpOptions.concurrency.value() != restartBaseline.concurrency;
+    }
 
     Implementation(
         Persistence::StateHolder* stateHolder,
@@ -169,6 +211,7 @@ Settings::Settings(
                   return;
               if (impl_->throttledSave.valid())
                   impl_->throttledSave();
+              impl_->recomputeRequiresRestart();
           },
           [this]()
           {
@@ -479,6 +522,8 @@ void Settings::applySettingsToUi()
 
             reloadInheritance();
 
+            impl_->captureRestartBaseline();
+
             Nui::globalEventContext.executeActiveEventsImmediately();
         }
     );
@@ -707,6 +752,20 @@ Nui::ElementRenderer Settings::operator()()
             }(
                 header(),
                 div{
+                    class_ = "settings-restart-banner",
+                }(
+                    observe(impl_->requiresRestart),
+                    [](bool restartRequired) -> Nui::ElementRenderer
+                    {
+                        if (!restartRequired)
+                            return Nui::nil();
+                        return Snc::messageStrip({
+                            .text = language->getObserved("settings", "restartRequiredMessage"),
+                            .styleVariant = Snc::StyleVariant::Warning,
+                        });
+                    }
+                ),
+                div{
                     class_ = "settings-page-content",
                 }(
                     side(),
@@ -817,14 +876,16 @@ Nui::ElementRenderer Settings::header()
                 .icon = GeneratedSvgs::decline(),
                 .attributes = {
                     onClick = [this]() {
+                        const bool needsRestart = impl_->requiresRestart.value();
                         impl_->events->settingsOpen = false;
-                        // Warning that most settings currently require a restart:
+                        if (!needsRestart)
+                            return;
                         impl_->confirmDialog->open({
                             .styleVariant = Snc::StyleVariant::Danger,
-                            .headerText = language->get("settings", "settingsClosedHeader"),
-                            .text = language->get("settings", "settingsClosedText"),
+                            .headerText = language->get("settings", "settingsRestartRequiredHeader"),
+                            .text = language->get("settings", "settingsRestartRequiredText"),
                             .buttons = ConfirmDialog::Button::Ok,
-                            .neverShowAgainId = "settingsClosedWarning",
+                            .neverShowAgainId = "settingsRestartRequiredWarning",
                         });
                     }
                 },

--- a/frontend/source/frontend/settings/log_options.cpp
+++ b/frontend/source/frontend/settings/log_options.cpp
@@ -78,6 +78,13 @@ LogOptions::LogOptions(std::function<void()> const& onChange)
           }
       }
     , onChange_{onChange}
+    , logLevelListener_{Nui::smartListen(
+          logLevel.state(),
+          [](Log::Level const& level)
+          {
+              Log::setLevel(level);
+          }
+      )}
 {}
 
 void LogOptions::applyToState(Persistence::LogOptions& state) const

--- a/shared_data/include/shared_data/file_operations/operations_reordered.hpp
+++ b/shared_data/include/shared_data/file_operations/operations_reordered.hpp
@@ -1,0 +1,34 @@
+#pragma once
+
+#include <ids/ids.hpp>
+#include <utility/describe.hpp>
+
+#include <cstdint>
+
+namespace SharedData
+{
+    /**
+     * @brief Backend → frontend notification fired after every `moveOperation`
+     *        RPC dispatch, regardless of whether the move actually applied.
+     *
+     *        - `applied=true`: backend reordered its regular deque; frontend
+     *          must mirror the change by moving the entry to @ref newIndex.
+     *        - `applied=false`: backend refused (not paused, id is in the
+     *          priority queue, op completed meanwhile, etc.); frontend
+     *          should leave its view unchanged but is free to clear any
+     *          pending UI affordance (drop indicator, etc.).
+     *
+     *        Sending the event on every branch lets the frontend treat this
+     *        as a definitive resolution signal rather than a fire-and-pray.
+     */
+    struct OperationsReordered
+    {
+        Ids::OperationId operationId;
+        // int32_t (not size_t/uint64_t) avoids a Nui RPC template-deduction
+        // conflict in the uint64 hi/lo split path. Queue sizes never come
+        // close to overflowing 2^31 in practice.
+        std::int32_t newIndex{0};
+        bool applied{false};
+    };
+    BOOST_DESCRIBE_STRUCT(OperationsReordered, (), (operationId, newIndex, applied))
+}

--- a/static/assets/languages/de_DE.yaml
+++ b/static/assets/languages/de_DE.yaml
@@ -185,8 +185,9 @@ fileTracking:
   headerCleanupButton: "Verwaiste bereinigen"
   headerCleanupRunning: "Bereinige…"
 settings:
-  settingsClosedHeader: "Die meisten Einstellungen erfordern einen Neustart"
-  settingsClosedText: "Im aktuellen Implementierungsstatus erfordern die meisten Einstellungsänderungen einen Neustart, um wirksam zu werden.\nBitte starten Sie die Anwendung neu, um die Änderungen anzuwenden.\nDies wird in Zukunft verbessert."
+  settingsRestartRequiredHeader: "Neustart erforderlich"
+  settingsRestartRequiredText: "Sie haben eine Einstellung geändert, die erst nach einem Neustart der Anwendung wirksam wird.\nBitte starten Sie die Anwendung neu, um die Änderungen anzuwenden."
+  restartRequiredMessage: "Eine Einstellung wurde geändert, die erst nach einem Neustart der Anwendung wirksam wird."
   loadingSettings: "Benutzeroberfläche für Einstellungen wird geladen"
   deleteSessionButton: "Sitzung löschen"
   deleteSessionConfirmHeader: "Sind Sie sicher, dass Sie diese Sitzung löschen möchten?"

--- a/static/assets/languages/de_DE.yaml
+++ b/static/assets/languages/de_DE.yaml
@@ -91,8 +91,10 @@ operationQueue:
   cancelAll: "Alle abbrechen"
   tabQueue: "Warteschlange"
   tabFailed: "Fehlgeschlagen"
+  tabPriority: "Priorität"
   resumeMinimizedSync: "Sync fortsetzen"
   restoreMinimizedSyncTitle: "Minimierten Sync-Dialog wiederherstellen"
+  kickToTopTitle: "Nach oben verschieben"
 syncDialog:
   titleFormat: "Synchronisieren: {} / {}"
   minimizeTitle: "Minimieren"

--- a/static/assets/languages/en_US.yaml
+++ b/static/assets/languages/en_US.yaml
@@ -184,8 +184,9 @@ fileTracking:
   headerCleanupButton: "Clean Up Orphaned"
   headerCleanupRunning: "Cleaning…"
 settings:
-  settingsClosedHeader: "Most Settings Require Restart"
-  settingsClosedText: "At current implementation status, most settings changes require a restart to take effect.\nPlease restart the application to apply the changes.\nThis will be improved in the future."
+  settingsRestartRequiredHeader: "Restart Required"
+  settingsRestartRequiredText: "You have changed a setting that only takes effect after the application is restarted.\nPlease restart the application to apply the changes."
+  restartRequiredMessage: "A setting was changed that only takes effect after an application restart."
   loadingSettings: "Loading Settings UI"
   deleteSessionButton: "Delete Session"
   deleteSessionConfirmHeader: "Are you sure you want to delete this session?"

--- a/static/assets/languages/en_US.yaml
+++ b/static/assets/languages/en_US.yaml
@@ -34,8 +34,10 @@ operationQueue:
   cancelAll: "Cancel All"
   tabQueue: "Queue"
   tabFailed: "Failed"
+  tabPriority: "Priority"
   resumeMinimizedSync: "Resume Sync"
   restoreMinimizedSyncTitle: "Restore minimized sync dialog"
+  kickToTopTitle: "Move to top of queue"
 syncDialog:
   titleFormat: "Synchronize: {} / {}"
   minimizeTitle: "Minimize"

--- a/static/styles/lumino/tabbar.css
+++ b/static/styles/lumino/tabbar.css
@@ -13,89 +13,218 @@
 |----------------------------------------------------------------------------*/
 
 .lm-TabBar {
-    min-height: 24px;
-    max-height: 24px;
+    --lm-tab-bg: color-mix(in srgb, var(--background-color) 86%, black);
+    --lm-tab-bg-hover: color-mix(in srgb, var(--background-color) 70%, var(--theme-color) 6%);
+    --lm-tab-bg-current: var(--background-color);
+    --lm-tab-border: color-mix(in srgb, var(--color) 14%, transparent);
+    --lm-tab-border-hover: color-mix(in srgb, var(--color) 24%, transparent);
+    --lm-tab-border-current: color-mix(in srgb, var(--theme-color) 38%, transparent);
+    --lm-tab-seam: color-mix(in srgb, var(--theme-color) 28%, transparent);
+    --lm-tab-color: var(--color-secondary);
+    --lm-tab-color-current: var(--color);
+    --lm-tab-accent: var(--theme-color);
+    --lm-tab-close: color-mix(in srgb, var(--color) 38%, transparent);
+    --lm-tab-close-bg-hover: color-mix(in srgb, var(--theme-color) 16%, transparent);
+
+    min-height: 28px;
+    max-height: 28px;
 }
 
 .lm-TabBar-content {
     min-width: 0;
     min-height: 0;
     align-items: flex-end;
-    border-bottom: 1px solid var(--color);
+    gap: 2px;
+    padding: 0 4px;
+    border-bottom: 1px solid var(--lm-tab-seam);
 }
 
 .lm-TabBar-tab {
-    padding: 0px 10px;
-    background: var(--background-color);
-    border: 1px solid var(--color);
-    border-radius: 4px 4px 0 0;
+    position: relative;
+    overflow: visible;
+    padding: 0 6px 0 9px;
+    background: var(--lm-tab-bg);
+    color: var(--lm-tab-color);
+    border: 1px solid var(--lm-tab-border);
     border-bottom: none;
+    border-radius: 7px 7px 0 0;
+    flex: 0 1 160px;
+    min-height: 24px;
+    max-height: 24px;
+    min-width: 48px;
+    margin-left: 0;
     font:
-        12px Helvetica,
-        Arial,
+        500 12px/24px Inter,
+        ui-sans-serif,
+        system-ui,
+        -apple-system,
+        "Segoe UI",
         sans-serif;
-    flex: 0 1 125px;
-    min-height: 20px;
-    max-height: 20px;
-    min-width: 35px;
-    margin-left: -1px;
-    line-height: 20px;
+    letter-spacing: 0.015em;
+    transition:
+        background-color 120ms ease,
+        color 120ms ease,
+        border-color 120ms ease,
+        box-shadow 180ms ease;
 }
 
-.lm-TabBar-tabLabel .lm-TabBar-tabInput {
-    padding: 0px;
-    border: 0px;
-    font:
-        12px Helvetica,
-        Arial,
-        sans-serif;
-}
-
-.lm-TabBar-tab.lm-mod-current {
-    background: var(--background-color);
+.lm-TabBar-tab::after {
+    content: '';
+    position: absolute;
+    left: 6%;
+    right: 6%;
+    bottom: -1px;
+    height: 2px;
+    border-radius: 99px;
+    background: var(--lm-tab-accent);
+    opacity: 0;
+    transform: scaleX(0.3);
+    transform-origin: center;
+    transition:
+        opacity 160ms ease,
+        transform 200ms cubic-bezier(0.22, 1, 0.36, 1);
+    pointer-events: none;
 }
 
 .lm-TabBar-tab:hover:not(.lm-mod-current) {
-    background: var(--brighter-background);
+    background: var(--lm-tab-bg-hover);
+    border-color: var(--lm-tab-border-hover);
+    color: var(--lm-tab-color-current);
+}
+
+.lm-TabBar-tab.lm-mod-current {
+    background: var(--lm-tab-bg-current);
+    color: var(--lm-tab-color-current);
+    border-color: var(--lm-tab-border-current);
+    min-height: 26px;
+    max-height: 26px;
+    box-shadow:
+        inset 0 1px 0 color-mix(in srgb, var(--theme-color) 10%, transparent),
+        0 6px 14px -8px rgba(0, 0, 0, 0.55);
+}
+
+.lm-TabBar-tab.lm-mod-current::after {
+    opacity: 1;
+    transform: scaleX(1);
+}
+
+.lm-TabBar-tabLabel {
+    padding: 0;
+}
+
+.lm-TabBar-tabLabel .lm-TabBar-tabInput {
+    padding: 0;
+    border: 0;
+    background: transparent;
+    color: var(--color);
+    font: inherit;
+    outline: 1px solid var(--lm-tab-accent);
+    outline-offset: 2px;
+    border-radius: 2px;
+}
+
+.lm-TabBar-tabIcon,
+.lm-TabBar-tabLabel,
+.lm-TabBar-tabCloseIcon {
+    display: inline-flex;
+    align-items: center;
+}
+
+.lm-TabBar-tabIcon {
+    margin-right: 6px;
+    opacity: 0.85;
+}
+
+.lm-TabBar-tab.lm-mod-closable > .lm-TabBar-tabCloseIcon {
+    position: relative;
+    margin-left: 6px;
+    width: 16px;
+    height: 16px;
+    flex: 0 0 auto;
+    align-self: center;
+    border-radius: 4px;
+    color: var(--lm-tab-close);
+    cursor: pointer;
+    transition:
+        background-color 100ms ease,
+        color 100ms ease;
+}
+
+.lm-TabBar-tab.lm-mod-closable > .lm-TabBar-tabCloseIcon:before,
+.lm-TabBar-tab.lm-mod-closable > .lm-TabBar-tabCloseIcon:after {
+    content: '';
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    width: 9px;
+    height: 1.5px;
+    background: currentColor;
+    border-radius: 1px;
+}
+
+.lm-TabBar-tab.lm-mod-closable > .lm-TabBar-tabCloseIcon:before {
+    transform: translate(-50%, -50%) rotate(45deg);
+}
+
+.lm-TabBar-tab.lm-mod-closable > .lm-TabBar-tabCloseIcon:after {
+    transform: translate(-50%, -50%) rotate(-45deg);
+}
+
+.lm-TabBar-tab.lm-mod-closable > .lm-TabBar-tabCloseIcon:hover {
+    background-color: var(--lm-tab-close-bg-hover);
+    color: var(--color);
+}
+
+.lm-TabBar-tab.lm-mod-current > .lm-TabBar-tabCloseIcon {
+    color: color-mix(in srgb, var(--color) 55%, transparent);
+}
+
+.lm-TabBar .lm-TabBar-addButton {
+    padding: 0 9px;
+    margin-left: 4px;
+    min-height: 24px;
+    line-height: 24px;
+    color: var(--lm-tab-close);
+    background: transparent;
+    border: 1px dashed var(--lm-tab-border);
+    border-bottom: none;
+    border-radius: 7px 7px 0 0;
+    cursor: pointer;
+    transition:
+        color 120ms ease,
+        border-color 120ms ease,
+        background-color 120ms ease;
+}
+
+.lm-TabBar .lm-TabBar-addButton:before {
+    content: '+';
+    font-weight: 600;
+    font-size: 14px;
+    line-height: 1;
+    display: inline-block;
+    transform: translateY(-1px);
+}
+
+.lm-TabBar .lm-TabBar-addButton:hover {
+    color: var(--theme-color);
+    border-color: var(--lm-tab-border-current);
+    border-style: solid;
+    background: color-mix(in srgb, var(--theme-color) 8%, transparent);
 }
 
 .lm-TabBar-tab:first-child {
     margin-left: 0;
 }
 
-.lm-TabBar-tab.lm-mod-current {
-    min-height: 23px;
-    max-height: 23px;
-    transform: translateY(1px);
-}
-
-.lm-TabBar-tabIcon,
-.lm-TabBar-tabLabel,
-.lm-TabBar-tabCloseIcon {
-    display: inline-block;
-}
-
-.lm-TabBar-tab.lm-mod-closable>.lm-TabBar-tabCloseIcon {
-    margin-left: 4px;
-}
-
-.lm-TabBar .lm-TabBar-addButton {
-    padding: 0px 6px;
-    border-bottom: 1px solid var(--color);
-}
-
-.lm-TabBar-tab.lm-mod-closable>.lm-TabBar-tabCloseIcon:before {
-    content: 'x';
-}
-
-.lm-TabBar .lm-TabBar-addButton:before {
-    content: '+';
-}
-
 .lm-TabBar-tab.lm-mod-drag-image {
-    min-height: 23px;
-    max-height: 23px;
-    min-width: 125px;
-    border: none;
-    box-shadow: 1px 1px 2px rgba(0, 0, 0, 0.3);
+    min-height: 26px;
+    max-height: 26px;
+    min-width: 140px;
+    border: 1px solid var(--lm-tab-border-current);
+    border-radius: 7px;
+    background: var(--lm-tab-bg-current);
+    color: var(--lm-tab-color-current);
+    box-shadow:
+        0 12px 28px -6px rgba(0, 0, 0, 0.55),
+        0 0 0 1px color-mix(in srgb, var(--theme-color) 35%, transparent);
 }

--- a/static/styles/operation_queue.css
+++ b/static/styles/operation_queue.css
@@ -126,17 +126,21 @@ header.opq-controls {
     overflow-y: auto;
     gap: 1px;
     min-height: 0;
-    grid-template-columns: min-content 1fr 1fr max-content max-content max-content;
+    /* 7 columns: kick-to-top (0 width when not paused) + icon + 2x body + clock + err + cancel.
+       The 0-width first column means the kick column collapses entirely on the
+       unpaused surface, so layout is identical to the pre-feature state. The
+       column width is rewritten to min-content under [data-paused] below. */
+    grid-template-columns: 0 min-content 1fr 1fr max-content max-content max-content;
     grid-auto-rows: 36px;
 }
 
-/* Transparent pass-through wrappers so cards remain direct grid children.
-   .opq-live-wrapper is emitted by the page-switch observe/renderer when the
-   user is on the live page; it hosts both priority and regular lists and must
-   also pass through so its grandchildren land as direct .opq-list grid cells. */
+.operation-queue[data-paused] .opq-list {
+    grid-template-columns: min-content min-content 1fr 1fr max-content max-content max-content;
+}
+
+/* Transparent pass-through wrappers so cards remain direct grid children. */
 .opq-priority-list,
-.opq-regular-list,
-.opq-live-wrapper {
+.opq-regular-list {
     display: contents;
 
     &>:nth-child(even) {
@@ -175,8 +179,9 @@ header.opq-controls {
     height: 36px;
     fill: currentColor;
 
-    /* first child — icon */
-    &>div:first-child {
+    /* second child — type icon (first child is the kick-to-top button which
+       collapses to 0 when not paused). */
+    &>div:nth-child(2) {
         width: 20px;
         height: 20px;
         margin-right: 8px;
@@ -205,9 +210,69 @@ header.opq-controls {
 .opq-card-subgrid {
     display: grid;
     grid-template-columns: subgrid;
-    grid-column: span 6;
+    grid-column: span 7;
     align-items: center;
     grid-template-rows: 36px;
+}
+
+/* Kick-to-top button.  Always rendered (per-card cost = 1 click closure),
+   visibility toggled purely via CSS rules driven by the root [data-paused]
+   attribute.  No per-card observed needed. */
+.op-kick-up {
+    width: 0;
+    overflow: hidden;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    color: var(--opq-muted);
+    cursor: pointer;
+    fill: currentColor;
+    pointer-events: none;
+    visibility: hidden;
+    transition: color 100ms ease;
+
+    & svg {
+        width: 14px;
+        height: 14px;
+    }
+
+    &:hover {
+        color: var(--opq-accent, #6cf);
+    }
+}
+
+/* Kick-to-top is only meaningful on the live regular queue. The `.opq-reorderable`
+   class is set exclusively on that surface, so Failed / Priority / history
+   pages — which reuse `.opq-regular-list` for their grid layout — never show
+   the button even while paused. */
+.operation-queue[data-paused] .opq-reorderable .op-kick-up {
+    width: 22px;
+    visibility: visible;
+    pointer-events: auto;
+    margin-right: 4px;
+}
+
+/* Drag affordances.  The card's `draggable=true` attribute is always set;
+   the dragstart handler at the list level cancels the drag when not paused.
+   These rules just communicate the state visually. */
+.operation-queue[data-paused] .opq-reorderable > .opq-card {
+    cursor: grab;
+}
+
+.operation-queue[data-paused] .opq-reorderable > .opq-card.opq-dragging {
+    cursor: grabbing;
+    opacity: 0.55;
+}
+
+/* Drop indicators — applied directly via classList from the dragover handler
+   to avoid an Observed<bool> per card.  Painted with inset box-shadow so they
+   don't shift layout. */
+.operation-queue[data-paused] .opq-reorderable > .opq-card.opq-drop-above {
+    box-shadow: inset 0 2px 0 var(--opq-accent, #6cf);
+}
+
+.operation-queue[data-paused] .opq-reorderable > .opq-card.opq-drop-below {
+    box-shadow: inset 0 -2px 0 var(--opq-accent, #6cf);
 }
 
 .opq-card:hover {

--- a/static/styles/settings.css
+++ b/static/styles/settings.css
@@ -47,10 +47,15 @@
     flex-grow: 1;
     display: grid;
     grid-template-columns: 1fr;
-    grid-template-rows: auto 1fr;
+    grid-template-rows: auto auto 1fr;
 
     background-color: var(--background-color);
     overflow: hidden;
+}
+
+.settings-restart-banner:not(:empty) {
+    padding: 8px 16px 0 16px;
+    background-color: var(--background-color);
 }
 
 .settings-page-header {

--- a/static/styles/settings.css
+++ b/static/styles/settings.css
@@ -58,6 +58,10 @@
     background-color: var(--background-color);
 }
 
+.setting-table-container > .script-nui-resizable-table {
+    max-height: 400px;
+}
+
 .settings-page-header {
     display: grid;
     grid-template-columns: auto auto 1fr auto;


### PR DESCRIPTION
- Show settings restart dialog and a new banner only on settings that actually require it.
- Improved lumino tab style.
- Allow for operations to be reordered
- Gave list and map settings a max height.