### PR TITLE
Archive Transfer Fixes

### DIFF
--- a/backend/include/backend/sftp/archive_download_operation.hpp
+++ b/backend/include/backend/sftp/archive_download_operation.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <backend/sftp/operation.hpp>
+#include <ssh/async/buffer_provider.hpp>
 #include <ssh/file_stream.hpp>
 #include <ssh/sftp_session.hpp>
 #include <tar_archive/archive.hpp>
@@ -9,7 +10,6 @@
 #include <tar_archive/compression.hpp>
 #include <shared_data/directory_entry.hpp>
 
-#include <array>
 #include <cstdint>
 #include <filesystem>
 #include <functional>
@@ -155,6 +155,6 @@ class ArchiveDownloadOperation : public Operation
     std::uint64_t currentEntryBytesRead_{0u};
     std::uint64_t totalBytesTransferred_{0u};
     std::uint64_t totalPayloadBytes_{0u};
-    std::array<char, 64u * 1024u> buffer_{};
+    SecureShell::BufferLease buffer_;
     std::filesystem::path tempPath_{};
 };

--- a/backend/include/backend/sftp/archive_download_operation.hpp
+++ b/backend/include/backend/sftp/archive_download_operation.hpp
@@ -2,6 +2,7 @@
 
 #include <backend/sftp/operation.hpp>
 #include <ssh/async/buffer_provider.hpp>
+#include <ssh/async/transfer_context.hpp>
 #include <ssh/file_stream.hpp>
 #include <ssh/sftp_session.hpp>
 #include <tar_archive/archive.hpp>
@@ -13,8 +14,10 @@
 #include <cstdint>
 #include <filesystem>
 #include <functional>
+#include <map>
 #include <optional>
 #include <string>
+#include <utility>
 #include <vector>
 
 /**
@@ -117,6 +120,29 @@ class ArchiveDownloadOperation : public Operation
 
     std::expected<void, Error> cancel(bool adoptCancelState) override;
 
+    /**
+     * @brief Ingest a preceding ScanOperation's walk of @p remoteRootPath.
+     *        Called by OperationQueue's scan-complete dispatcher before this
+     *        operation runs; when prepareInStrand later flattens its roots it
+     *        consults the stored map and reuses these entries instead of
+     *        re-recursing, so the scan work is visible (as a separate card)
+     *        rather than silently buried inside prepare.
+     *
+     *        Safe to call multiple times — one call per directory root in
+     *        @ref Options::entries.  Matching is by @p remoteRootPath which
+     *        must equal the root entry's full remote path
+     *        (fullPath-or-fallback-to-path in the root @ref DirectoryEntry).
+     *
+     *        Threading: invoked on the queue's asio strand between SFTP-strand
+     *        work batches, so no extra synchronisation is required against
+     *        prepareInStrand (which runs on the SFTP strand).
+     */
+    void setScanResultForRoot(
+        std::filesystem::path const& remoteRootPath,
+        std::vector<SharedData::DirectoryEntry> entries,
+        std::uint64_t totalBytes
+    );
+
   private:
     /**
      * @brief Pairs an archive-relative metadata record (what goes into the tar
@@ -132,8 +158,17 @@ class ArchiveDownloadOperation : public Operation
 
     std::expected<void, Error> prepareInStrand();
     std::expected<void, Error> flattenRootsInStrand();
-    std::expected<void, Error> recurseIntoDirectoryInStrand(
-        std::filesystem::path const& remoteFullPath,
+    /**
+     * @brief Expand a preceding ScanOperation's flat entry vector into the
+     *        op's ResolvedEntry list, prefixing each entry's tar path with
+     *        @p archivePrefix and composing remote paths under
+     *        @p remoteRootFullPath. Index 0 (the synthetic scan root) is
+     *        skipped because the root directory entry is emitted separately
+     *        by flattenRootsInStrand.
+     */
+    void appendPrescannedInStrand(
+        std::vector<SharedData::DirectoryEntry> const& entries,
+        std::filesystem::path const& remoteRootFullPath,
         std::filesystem::path const& archivePrefix
     );
     std::expected<void, Error> openNextEntryInStrand();
@@ -157,4 +192,20 @@ class ArchiveDownloadOperation : public Operation
     std::uint64_t totalPayloadBytes_{0u};
     SecureShell::BufferLease buffer_;
     std::filesystem::path tempPath_{};
+    /**
+     * @brief Pre-scanned entry lists delivered by preceding ScanOperation(s),
+     *        keyed by the directory root's remote full path. flattenRoots
+     *        looks each directory root up here before falling back to a live
+     *        recurseIntoDirectoryInStrand listing.
+     */
+    std::map<std::filesystem::path, std::pair<std::vector<SharedData::DirectoryEntry>, std::uint64_t>>
+        prescannedRoots_{};
+    /**
+     * @brief Reused purely for its bytes-transferred + B/s meter machinery;
+     *        the async pause/cancel side of the class is unused here because
+     *        archive download drives chunks via readSomeInStrand rather than
+     *        the FileStream async path that normally owns this context.
+     */
+    std::shared_ptr<SecureShell::AsyncTransferContext> throughputMeter_{
+        std::make_shared<SecureShell::AsyncTransferContext>()};
 };

--- a/backend/include/backend/sftp/archive_upload_operation.hpp
+++ b/backend/include/backend/sftp/archive_upload_operation.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <backend/sftp/operation.hpp>
+#include <ssh/async/buffer_provider.hpp>
 #include <ssh/file_stream.hpp>
 #include <ssh/sftp_session.hpp>
 #include <tar_archive/archive.hpp>
@@ -9,7 +10,6 @@
 #include <tar_archive/compression.hpp>
 #include <shared_data/directory_entry.hpp>
 
-#include <array>
 #include <cstdint>
 #include <filesystem>
 #include <fstream>
@@ -131,5 +131,5 @@ class ArchiveUploadOperation : public Operation
     std::uint64_t currentEntryBytesRead_{0u};
     std::uint64_t totalBytesTransferred_{0u};
     std::uint64_t totalPayloadBytes_{0u};
-    std::array<char, 64u * 1024u> buffer_{};
+    SecureShell::BufferLease buffer_;
 };

--- a/backend/include/backend/sftp/archive_upload_operation.hpp
+++ b/backend/include/backend/sftp/archive_upload_operation.hpp
@@ -2,6 +2,7 @@
 
 #include <backend/sftp/operation.hpp>
 #include <ssh/async/buffer_provider.hpp>
+#include <ssh/async/transfer_context.hpp>
 #include <ssh/file_stream.hpp>
 #include <ssh/sftp_session.hpp>
 #include <tar_archive/archive.hpp>
@@ -14,8 +15,11 @@
 #include <filesystem>
 #include <fstream>
 #include <functional>
+#include <map>
+#include <memory>
 #include <optional>
 #include <string>
+#include <utility>
 #include <vector>
 
 /**
@@ -94,6 +98,24 @@ class ArchiveUploadOperation : public Operation
 
     std::expected<void, Error> cancel(bool adoptCancelState) override;
 
+    /**
+     * @brief Ingest a preceding LocalScanOperation's walk of @p localRootPath.
+     *        Mirrors ArchiveDownloadOperation::setScanResultForRoot — the
+     *        OperationQueue dispatcher calls this once per directory root
+     *        before prepareInStrand runs, and flattenRoots consumes the stored
+     *        entries instead of self-recursing so the scan work is visible as
+     *        a separate queue card.
+     *
+     *        Safe to call multiple times (one per directory root in
+     *        @ref Options::localPaths).  Matching is by the root's path as
+     *        passed in the options — prepareInStrand looks up the same key.
+     */
+    void setScanResultForRoot(
+        std::filesystem::path const& localRootPath,
+        std::vector<SharedData::DirectoryEntry> entries,
+        std::uint64_t totalBytes
+    );
+
   private:
     /**
      * @brief Archive-relative metadata paired with the full local source path.
@@ -107,9 +129,18 @@ class ArchiveUploadOperation : public Operation
     };
 
     std::expected<void, Error> prepareInStrand();
-    void flattenRoots();
-    void recurseIntoDirectory(
-        std::filesystem::path const& localRoot, std::filesystem::path const& archivePrefix
+    std::expected<void, Error> flattenRoots();
+    /**
+     * @brief Expand a preceding LocalScanOperation's flat entry vector into
+     *        this op's ResolvedEntry list, prefixing each entry's tar path
+     *        with @p archivePrefix and composing local full paths under
+     *        @p localRootFullPath. Index 0 (the synthetic walker root) is
+     *        skipped since its tar header is emitted by flattenRoots.
+     */
+    void appendPrescannedFromScan(
+        std::vector<SharedData::DirectoryEntry> const& entries,
+        std::filesystem::path const& localRootFullPath,
+        std::filesystem::path const& archivePrefix
     );
     std::expected<void, Error> openNextEntryInStrand();
     std::expected<bool, Error> readChunkInStrand();
@@ -132,4 +163,20 @@ class ArchiveUploadOperation : public Operation
     std::uint64_t totalBytesTransferred_{0u};
     std::uint64_t totalPayloadBytes_{0u};
     SecureShell::BufferLease buffer_;
+    /**
+     * @brief Pre-scanned entry lists delivered by preceding
+     *        LocalScanOperation(s), keyed by the directory root's local full
+     *        path. flattenRoots looks each directory root up here and errors
+     *        out if none is present — there is no self-contained recurse.
+     */
+    std::map<std::filesystem::path, std::pair<std::vector<SharedData::DirectoryEntry>, std::uint64_t>>
+        prescannedRoots_{};
+    /**
+     * @brief Reused purely for its bytes-transferred + B/s meter machinery;
+     *        the async pause/cancel side is unused because archive upload
+     *        drives writes via writeInStrand rather than the FileStream async
+     *        path that normally owns this context.
+     */
+    std::shared_ptr<SecureShell::AsyncTransferContext> throughputMeter_{
+        std::make_shared<SecureShell::AsyncTransferContext>()};
 };

--- a/backend/include/backend/sftp/download_operation.hpp
+++ b/backend/include/backend/sftp/download_operation.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <backend/sftp/operation.hpp>
+#include <ssh/async/buffer_provider.hpp>
 #include <ssh/file_stream.hpp>
 #include <ssh/sftp_session.hpp>
 #include <nui/utility/move_detector.hpp>
@@ -131,6 +132,6 @@ class DownloadOperation : public Operation
     std::weak_ptr<SecureShell::IFileStream> fileStream_;
     DownloadOperationOptions options_;
     std::ofstream localFile_;
-    std::array<char, 16384> buffer_;
+    SecureShell::BufferLease buffer_;
     std::shared_ptr<SecureShell::AsyncTransferContext> asyncTransferContext_;
 };

--- a/backend/include/backend/sftp/upload_operation.hpp
+++ b/backend/include/backend/sftp/upload_operation.hpp
@@ -1,7 +1,9 @@
 #pragma once
 
 #include <backend/sftp/operation.hpp>
+#include <ssh/async/buffer_provider.hpp>
 #include <ssh/file_stream.hpp>
+#include <ssh/sftp_session.hpp>
 #include <nui/utility/move_detector.hpp>
 #include <persistence/state/sftp_options.hpp>
 
@@ -134,6 +136,6 @@ class UploadOperation : public Operation
     bool isSymlink_{false};
     std::size_t leftToUpload_{0};
     std::size_t totalSize_{0};
-    std::array<char, 16384> buffer_{};
+    SecureShell::BufferLease buffer_;
     std::shared_ptr<SecureShell::AsyncTransferContext> asyncTransferContext_;
 };

--- a/backend/source/backend/sftp/archive_download_operation.cpp
+++ b/backend/source/backend/sftp/archive_download_operation.cpp
@@ -188,7 +188,13 @@ ArchiveDownloadOperation::workInStrand()
                 if (currentEntryIndex_ >= resolvedEntries_.size())
                 {
                     state_ = Finalizing;
-                    options_.progressCallback(0u, totalPayloadBytes_, totalPayloadBytes_, 0);
+                    throughputMeter_->calculateBytesPerSecond();
+                    options_.progressCallback(
+                        0u,
+                        totalPayloadBytes_,
+                        totalPayloadBytes_,
+                        throughputMeter_->bytesPerSecond()
+                    );
                     [[fallthrough]];
                 }
                 else
@@ -318,9 +324,26 @@ std::expected<void, Operation::Error> ArchiveDownloadOperation::flattenRootsInSt
             dirEntry.tarMeta.size = 0u;
             resolvedEntries_.push_back(std::move(dirEntry));
 
-            const auto recurseResult = recurseIntoDirectoryInStrand(rootFullPath, basename);
-            if (!recurseResult.has_value())
-                return std::unexpected(recurseResult.error());
+            // Directory roots are expanded exclusively from a preceding
+            // ScanOperation's results — there is no self-contained recurse
+            // fallback, so a visible scan card is always the source of truth
+            // for this op's entry list.
+            const auto it = prescannedRoots_.find(rootFullPath);
+            if (it == prescannedRoots_.end())
+            {
+                Log::error(
+                    "ArchiveDownloadOperation: missing pre-scanned entries for directory root '{}'",
+                    rootFullPath.generic_string()
+                );
+                return std::unexpected(Error{
+                    .type = ErrorType::ImplementationError,
+                    .extraInfo = fmt::format(
+                        "no pre-scanned entries for directory root '{}'",
+                        rootFullPath.generic_string()
+                    ),
+                });
+            }
+            appendPrescannedInStrand(it->second.first, rootFullPath, basename);
         }
         else
         {
@@ -334,33 +357,21 @@ std::expected<void, Operation::Error> ArchiveDownloadOperation::flattenRootsInSt
     return {};
 }
 
-std::expected<void, Operation::Error> ArchiveDownloadOperation::recurseIntoDirectoryInStrand(
-    std::filesystem::path const& remoteFullPath, std::filesystem::path const& archivePrefix
+void ArchiveDownloadOperation::appendPrescannedInStrand(
+    std::vector<SharedData::DirectoryEntry> const& entries,
+    std::filesystem::path const& remoteRootFullPath,
+    std::filesystem::path const& archivePrefix
 )
 {
-    auto listResult = sftp_->listDirectoryInStrand(remoteFullPath);
-    if (!listResult.has_value())
+    // Index 0 is the synthetic scan root (the directory itself); the caller
+    // emitted its tar header already, so we start at 1 and consume the
+    // walker's flat depth-first entry list.
+    for (std::size_t idx = 1u; idx < entries.size(); ++idx)
     {
-        Log::error(
-            "ArchiveDownloadOperation: listDirectory failed for '{}': {}",
-            remoteFullPath.generic_string(),
-            listResult.error().message
-        );
-        return std::unexpected(Error{
-            .type = ErrorType::SftpError,
-            .sftpError = listResult.error(),
-            .extraInfo = fmt::format("listing remote directory '{}'", remoteFullPath.generic_string()),
-        });
-    }
-
-    for (auto const& child : listResult.value())
-    {
-        const std::string name = child.path.filename().generic_string();
-        if (name == "." || name == "..")
-            continue;
-
-        const auto childFullRemote = remoteFullPath / child.path;
-        const auto childArchivePath = archivePrefix / child.path;
+        auto const& child = entries[idx];
+        const auto relPath = SharedData::fullPathRelative(entries, child);
+        const auto childArchivePath = archivePrefix / relPath;
+        const auto childFullRemote = remoteRootFullPath / relPath;
 
         if (child.type == SharedData::FileType::Regular)
         {
@@ -380,22 +391,16 @@ std::expected<void, Operation::Error> ArchiveDownloadOperation::recurseIntoDirec
             dirEntry.tarMeta.fullPath = childArchivePath;
             dirEntry.tarMeta.size = 0u;
             resolvedEntries_.push_back(std::move(dirEntry));
-
-            const auto recurseResult =
-                recurseIntoDirectoryInStrand(childFullRemote, childArchivePath);
-            if (!recurseResult.has_value())
-                return std::unexpected(recurseResult.error());
         }
         else
         {
             Log::warn(
-                "ArchiveDownloadOperation: skipping non-regular child '{}' (type={})",
+                "ArchiveDownloadOperation: skipping non-regular pre-scanned child '{}' (type={})",
                 childFullRemote.generic_string(),
                 static_cast<int>(child.type)
             );
         }
     }
-    return {};
 }
 
 std::expected<void, Operation::Error> ArchiveDownloadOperation::openNextEntryInStrand()
@@ -539,7 +544,13 @@ std::expected<bool, Operation::Error> ArchiveDownloadOperation::readChunkInStran
 
     currentEntryBytesRead_ += static_cast<std::uint64_t>(bytesRead);
     totalBytesTransferred_ += static_cast<std::uint64_t>(bytesRead);
-    options_.progressCallback(0u, totalPayloadBytes_, totalBytesTransferred_, 0);
+    throughputMeter_->addBytesTransferred(
+        static_cast<SecureShell::AsyncTransferContext::SignedSizeType>(bytesRead)
+    );
+    throughputMeter_->calculateBytesPerSecond();
+    options_.progressCallback(
+        0u, totalPayloadBytes_, totalBytesTransferred_, throughputMeter_->bytesPerSecond()
+    );
 
     if (currentEntryBytesRead_ >= resolved.tarMeta.size)
     {
@@ -636,6 +647,17 @@ std::expected<void, Operation::Error> ArchiveDownloadOperation::cancel(bool adop
     }
     cleanup();
     return {};
+}
+
+void ArchiveDownloadOperation::setScanResultForRoot(
+    std::filesystem::path const& remoteRootPath,
+    std::vector<SharedData::DirectoryEntry> entries,
+    std::uint64_t totalBytes
+)
+{
+    prescannedRoots_.insert_or_assign(
+        remoteRootPath, std::make_pair(std::move(entries), totalBytes)
+    );
 }
 
 void ArchiveDownloadOperation::cleanup()

--- a/backend/source/backend/sftp/archive_download_operation.cpp
+++ b/backend/source/backend/sftp/archive_download_operation.cpp
@@ -275,6 +275,19 @@ std::expected<void, Operation::Error> ArchiveDownloadOperation::prepareInStrand(
         return std::unexpected(archiveErrorToOperationError(sinkOrError.error()));
     }
     writer_ = TarArchive::Writer::makeFromSink(std::move(*sinkOrError));
+
+    buffer_ = sftp_->bufferProvider().lease(totalPayloadBytes_);
+    if (buffer_.empty())
+    {
+        Log::error("ArchiveDownloadOperation: No transfer buffer available from pool.");
+        return std::unexpected(Error{
+            .type = ErrorType::SftpError,
+            .sftpError = SecureShell::SftpError{
+                .message = "No buffer available from pool",
+                .wrapperError = SecureShell::WrapperErrors::BufferUnavailable,
+            },
+        });
+    }
     return {};
 }
 

--- a/backend/source/backend/sftp/archive_upload_operation.cpp
+++ b/backend/source/backend/sftp/archive_upload_operation.cpp
@@ -187,7 +187,13 @@ std::expected<Operation::WorkStatus, Operation::Error> ArchiveUploadOperation::w
                 if (currentEntryIndex_ >= resolvedEntries_.size())
                 {
                     state_ = Finalizing;
-                    options_.progressCallback(0u, totalPayloadBytes_, totalPayloadBytes_, 0);
+                    throughputMeter_->calculateBytesPerSecond();
+                    options_.progressCallback(
+                        0u,
+                        totalPayloadBytes_,
+                        totalPayloadBytes_,
+                        throughputMeter_->bytesPerSecond()
+                    );
                     [[fallthrough]];
                 }
                 else
@@ -234,7 +240,7 @@ std::expected<Operation::WorkStatus, Operation::Error> ArchiveUploadOperation::w
     return enterErrorState<WorkStatus>({.type = ErrorType::UnknownWorkState});
 }
 
-void ArchiveUploadOperation::flattenRoots()
+std::expected<void, Operation::Error> ArchiveUploadOperation::flattenRoots()
 {
     resolvedEntries_.clear();
     resolvedEntries_.reserve(options_.localPaths.size());
@@ -249,8 +255,7 @@ void ArchiveUploadOperation::flattenRoots()
 
         if (rootEntry->type == SharedData::FileType::Regular)
         {
-            if (rootEntry->type == SharedData::FileType::Regular)
-                totalPayloadBytes_ += rootEntry->size;
+            totalPayloadBytes_ += rootEntry->size;
             ResolvedEntry resolved{};
             resolved.tarMeta = std::move(*rootEntry);
             resolved.localFullPath = localRoot;
@@ -264,7 +269,25 @@ void ArchiveUploadOperation::flattenRoots()
             dirEntry.localFullPath.clear();
             resolvedEntries_.push_back(std::move(dirEntry));
 
-            recurseIntoDirectory(localRoot, basename);
+            // Directory roots are expanded exclusively from a preceding
+            // LocalScanOperation's results — the archive op no longer
+            // recurses itself, so the scan phase is always a visible card.
+            const auto it = prescannedRoots_.find(localRoot);
+            if (it == prescannedRoots_.end())
+            {
+                Log::error(
+                    "ArchiveUploadOperation: missing pre-scanned entries for directory root '{}'",
+                    localRoot.generic_string()
+                );
+                return std::unexpected(Error{
+                    .type = ErrorType::ImplementationError,
+                    .extraInfo = fmt::format(
+                        "no pre-scanned entries for directory root '{}'",
+                        localRoot.generic_string()
+                    ),
+                });
+            }
+            appendPrescannedFromScan(it->second.first, localRoot, basename);
         }
         else
         {
@@ -275,78 +298,62 @@ void ArchiveUploadOperation::flattenRoots()
             );
         }
     }
+    return {};
 }
 
-void ArchiveUploadOperation::recurseIntoDirectory(
-    std::filesystem::path const& localRoot, std::filesystem::path const& archivePrefix
+void ArchiveUploadOperation::appendPrescannedFromScan(
+    std::vector<SharedData::DirectoryEntry> const& entries,
+    std::filesystem::path const& localRootFullPath,
+    std::filesystem::path const& archivePrefix
 )
 {
-    std::error_code iterErr{};
-    std::filesystem::recursive_directory_iterator walker{
-        localRoot,
-        std::filesystem::directory_options::skip_permission_denied,
-        iterErr,
-    };
-    if (iterErr)
+    // Index 0 is the synthetic scan root (the directory itself); the caller
+    // emitted its tar header already, so we start at 1 and consume the
+    // walker's flat depth-first entry list — mirrors the download op's
+    // appendPrescannedInStrand.
+    for (std::size_t idx = 1u; idx < entries.size(); ++idx)
     {
-        Log::warn(
-            "ArchiveUploadOperation: cannot enumerate '{}': {}",
-            localRoot.generic_string(),
-            iterErr.message()
-        );
-        return;
-    }
+        auto const& child = entries[idx];
+        const auto relPath = SharedData::fullPathRelative(entries, child);
+        const auto childArchivePath = archivePrefix / relPath;
+        const auto childLocalFull = localRootFullPath / relPath;
 
-    const std::filesystem::recursive_directory_iterator end{};
-    while (walker != end)
-    {
-        std::error_code advanceErr{};
-        auto const& dirEntry = *walker;
-
-        const auto relativePath =
-            std::filesystem::relative(dirEntry.path(), localRoot, advanceErr);
-        if (advanceErr)
+        if (child.type == SharedData::FileType::Regular)
         {
-            walker.increment(advanceErr);
-            continue;
+            ResolvedEntry resolved{};
+            resolved.tarMeta = child;
+            resolved.tarMeta.path = childArchivePath;
+            resolved.tarMeta.fullPath = childArchivePath;
+            resolved.localFullPath = childLocalFull;
+            totalPayloadBytes_ += resolved.tarMeta.size;
+            resolvedEntries_.push_back(std::move(resolved));
         }
-        const auto archivePath = archivePrefix / relativePath;
-
-        auto resolvedMeta = localPathToEntry(dirEntry.path(), archivePath);
-        if (resolvedMeta)
+        else if (child.type == SharedData::FileType::Directory)
         {
-            if (resolvedMeta->type == SharedData::FileType::Regular)
-            {
-                totalPayloadBytes_ += resolvedMeta->size;
-                ResolvedEntry resolved{};
-                resolved.tarMeta = std::move(*resolvedMeta);
-                resolved.localFullPath = dirEntry.path();
-                resolvedEntries_.push_back(std::move(resolved));
-            }
-            else if (resolvedMeta->type == SharedData::FileType::Directory)
-            {
-                resolvedMeta->size = 0u;
-                ResolvedEntry resolvedDir{};
-                resolvedDir.tarMeta = std::move(*resolvedMeta);
-                resolvedDir.localFullPath.clear();
-                resolvedEntries_.push_back(std::move(resolvedDir));
-            }
-            else
-            {
-                Log::warn(
-                    "ArchiveUploadOperation: skipping non-regular child '{}' (type={})",
-                    dirEntry.path().generic_string(),
-                    static_cast<int>(resolvedMeta->type)
-                );
-            }
+            ResolvedEntry dirEntry{};
+            dirEntry.tarMeta = child;
+            dirEntry.tarMeta.path = childArchivePath;
+            dirEntry.tarMeta.fullPath = childArchivePath;
+            dirEntry.tarMeta.size = 0u;
+            dirEntry.localFullPath.clear();
+            resolvedEntries_.push_back(std::move(dirEntry));
         }
-        walker.increment(advanceErr);
+        else
+        {
+            Log::warn(
+                "ArchiveUploadOperation: skipping non-regular pre-scanned child '{}' (type={})",
+                childLocalFull.generic_string(),
+                static_cast<int>(child.type)
+            );
+        }
     }
 }
 
 std::expected<void, Operation::Error> ArchiveUploadOperation::prepareInStrand()
 {
-    flattenRoots();
+    const auto flattenResult = flattenRoots();
+    if (!flattenResult.has_value())
+        return std::unexpected(flattenResult.error());
 
     if (resolvedEntries_.empty())
         return std::unexpected(Error{
@@ -515,7 +522,13 @@ std::expected<bool, Operation::Error> ArchiveUploadOperation::readChunkInStrand(
 
     currentEntryBytesRead_ += bytesRead;
     totalBytesTransferred_ += bytesRead;
-    options_.progressCallback(0u, totalPayloadBytes_, totalBytesTransferred_, 0);
+    throughputMeter_->addBytesTransferred(
+        static_cast<SecureShell::AsyncTransferContext::SignedSizeType>(bytesRead)
+    );
+    throughputMeter_->calculateBytesPerSecond();
+    options_.progressCallback(
+        0u, totalPayloadBytes_, totalBytesTransferred_, throughputMeter_->bytesPerSecond()
+    );
 
     if (currentEntryBytesRead_ >= resolved.tarMeta.size)
     {
@@ -600,6 +613,17 @@ std::expected<void, Operation::Error> ArchiveUploadOperation::cancel(bool adoptC
     }
     cleanup();
     return {};
+}
+
+void ArchiveUploadOperation::setScanResultForRoot(
+    std::filesystem::path const& localRootPath,
+    std::vector<SharedData::DirectoryEntry> entries,
+    std::uint64_t totalBytes
+)
+{
+    prescannedRoots_.insert_or_assign(
+        localRootPath, std::make_pair(std::move(entries), totalBytes)
+    );
 }
 
 void ArchiveUploadOperation::cleanup()

--- a/backend/source/backend/sftp/archive_upload_operation.cpp
+++ b/backend/source/backend/sftp/archive_upload_operation.cpp
@@ -402,6 +402,19 @@ std::expected<void, Operation::Error> ArchiveUploadOperation::prepareInStrand()
     }
 
     writer_ = TarArchive::Writer::makeFromSink(std::move(*wrappedSink));
+
+    buffer_ = sftp_->bufferProvider().lease(totalPayloadBytes_);
+    if (buffer_.empty())
+    {
+        Log::error("ArchiveUploadOperation: No transfer buffer available from pool.");
+        return std::unexpected(Error{
+            .type = ErrorType::SftpError,
+            .sftpError = SecureShell::SftpError{
+                .message = "No buffer available from pool",
+                .wrapperError = SecureShell::WrapperErrors::BufferUnavailable,
+            },
+        });
+    }
     return {};
 }
 

--- a/backend/source/backend/sftp/bulk_download_operation.cpp
+++ b/backend/source/backend/sftp/bulk_download_operation.cpp
@@ -102,14 +102,7 @@ std::expected<BulkDownloadOperation::WorkStatus, BulkDownloadOperation::Error> B
             currentIndex_ = 1;
             enterState(Running);
             options_.overallProgressCallback(
-                options_.localPath,
-                currentIndex_,
-                entries_.size() - 1,
-                0,
-                0,
-                0,
-                totalBytes_,
-                bulkBytesPerSecond_
+                options_.localPath, currentIndex_, entries_.size() - 1, 0, 0, 0, totalBytes_, bulkBytesPerSecond_
             );
             return WorkStatus::MoreWork;
         }
@@ -127,8 +120,14 @@ std::expected<BulkDownloadOperation::WorkStatus, BulkDownloadOperation::Error> B
                 if (!prescannedPathOverride_.empty())
                 {
                     options_.overallProgressCallback(
-                        options_.localPath, currentIndex_, entries_.size(),
-                        0, 0, currentBytes_, totalBytes_, bulkBytesPerSecond_
+                        options_.localPath,
+                        currentIndex_,
+                        entries_.size(),
+                        0,
+                        0,
+                        currentBytes_,
+                        totalBytes_,
+                        bulkBytesPerSecond_
                     );
                 }
                 Log::info("BulkDownloadOperation: Bulk download completed.");
@@ -368,6 +367,12 @@ void BulkDownloadOperation::completeCurrentDownload()
     currentBytes_ += currentDownload_->totalSize();
     currentDownload_.reset();
     ++currentIndex_;
+    if (!prescannedPathOverride_.empty() && currentIndex_ == entries_.size())
+    {
+        options_.overallProgressCallback(
+            options_.localPath, currentIndex_, entries_.size(), 0, 0, currentBytes_, totalBytes_, bulkBytesPerSecond_
+        );
+    }
 }
 
 std::expected<BulkDownloadOperation::WorkStatus, BulkDownloadOperation::Error> BulkDownloadOperation::workAsArchive()

--- a/backend/source/backend/sftp/bulk_upload_operation.cpp
+++ b/backend/source/backend/sftp/bulk_upload_operation.cpp
@@ -92,14 +92,7 @@ std::expected<BulkUploadOperation::WorkStatus, BulkUploadOperation::Error> BulkU
             currentIndex_ = 1;
             enterState(Running);
             options_.overallProgressCallback(
-                options_.remotePath,
-                currentIndex_,
-                entries_.size() - 1,
-                0,
-                0,
-                0,
-                totalBytes_,
-                bulkBytesPerSecond_
+                options_.remotePath, currentIndex_, entries_.size() - 1, 0, 0, 0, totalBytes_, bulkBytesPerSecond_
             );
             return WorkStatus::MoreWork;
         }
@@ -120,8 +113,14 @@ std::expected<BulkUploadOperation::WorkStatus, BulkUploadOperation::Error> BulkU
                 if (!prescannedPathOverride_.empty())
                 {
                     options_.overallProgressCallback(
-                        options_.remotePath, currentIndex_, entries_.size(),
-                        0, 0, currentBytes_, totalBytes_, bulkBytesPerSecond_
+                        options_.remotePath,
+                        currentIndex_,
+                        entries_.size(),
+                        0,
+                        0,
+                        currentBytes_,
+                        totalBytes_,
+                        bulkBytesPerSecond_
                     );
                 }
                 Log::info("BulkUploadOperation: Bulk upload completed.");
@@ -151,7 +150,14 @@ std::expected<BulkUploadOperation::WorkStatus, BulkUploadOperation::Error> BulkU
                 // has no synthetic root, so every entry counts.
                 const std::uint64_t fileCount = entries_.size() - (prescannedPathOverride_.empty() ? 1 : 0);
                 options_.overallProgressCallback(
-                    fullRemotePath(entry), currentIndex_, fileCount, 0, 0, currentBytes_, totalBytes_, bulkBytesPerSecond_
+                    fullRemotePath(entry),
+                    currentIndex_,
+                    fileCount,
+                    0,
+                    0,
+                    currentBytes_,
+                    totalBytes_,
+                    bulkBytesPerSecond_
                 );
             }
             else if (entry.isRegularFile() || entry.isSymlink())
@@ -365,6 +371,12 @@ void BulkUploadOperation::completeCurrentUpload()
     currentBytes_ += currentUpload_->totalSize();
     currentUpload_.reset();
     ++currentIndex_;
+    if (!prescannedPathOverride_.empty() && currentIndex_ == entries_.size())
+    {
+        options_.overallProgressCallback(
+            options_.remotePath, currentIndex_, entries_.size(), 0, 0, currentBytes_, totalBytes_, bulkBytesPerSecond_
+        );
+    }
 }
 
 SharedData::OperationType BulkUploadOperation::type() const

--- a/backend/source/backend/sftp/download_operation.cpp
+++ b/backend/source/backend/sftp/download_operation.cpp
@@ -544,6 +544,19 @@ std::expected<void, DownloadOperation::Error> DownloadOperation::prepareInStrand
     if (options_.entry->isSymlink())
         return {};
 
+    buffer_ = sftp_->bufferProvider().leaseForTransfer(options_.entry->size, stream->readLengthLimit());
+    if (buffer_.empty())
+    {
+        Log::error("DownloadOperation: No transfer buffer available from pool.");
+        return std::unexpected(Error{
+            .type = ErrorType::SftpError,
+            .sftpError = SecureShell::SftpError{
+                .message = "No buffer available from pool",
+                .wrapperError = SecureShell::WrapperErrors::BufferUnavailable,
+            },
+        });
+    }
+
     if (options_.reserveSpace && options_.entry->size != 0)
     {
         const auto pos = localFile_.tellp();

--- a/backend/source/backend/sftp/operation_queue.cpp
+++ b/backend/source/backend/sftp/operation_queue.cpp
@@ -607,6 +607,19 @@ bool OperationQueue::workQueue(std::deque<std::pair<Ids::OperationId, std::uniqu
                 (item.queueIndex + 1 < queue.size()) ? queue[item.queueIndex + 1].second.get() : nullptr;
             if (operation->type() == SharedData::OperationType::Scan)
             {
+                // Walk past any additional queued scans to find the archive
+                // op that consumes multi-root scan batches — each per-root
+                // scan delivers its slice into the same ArchiveDownload.
+                Operation* nextNonScan = nullptr;
+                for (std::size_t lookahead = item.queueIndex + 1; lookahead < queue.size(); ++lookahead)
+                {
+                    auto* candidate = queue[lookahead].second.get();
+                    if (candidate->type() != SharedData::OperationType::Scan)
+                    {
+                        nextNonScan = candidate;
+                        break;
+                    }
+                }
                 if (next && next->type() == SharedData::OperationType::BulkDownload)
                 {
                     auto* scan = static_cast<ScanOperation*>(operation.get());
@@ -616,6 +629,13 @@ bool OperationQueue::workQueue(std::deque<std::pair<Ids::OperationId, std::uniqu
                 {
                     auto* scan = static_cast<ScanOperation*>(operation.get());
                     static_cast<DeleteOperation*>(next)->setScanResult(scan->ejectEntries(), scan->totalBytes());
+                }
+                else if (nextNonScan && nextNonScan->type() == SharedData::OperationType::ArchiveDownload)
+                {
+                    auto* scan = static_cast<ScanOperation*>(operation.get());
+                    static_cast<ArchiveDownloadOperation*>(nextNonScan)->setScanResultForRoot(
+                        scan->remotePath(), scan->ejectEntries(), scan->totalBytes()
+                    );
                 }
                 else
                 {
@@ -638,10 +658,29 @@ bool OperationQueue::workQueue(std::deque<std::pair<Ids::OperationId, std::uniqu
             }
             else if (operation->type() == SharedData::OperationType::LocalScan)
             {
+                // Mirror the remote-Scan branch: walk past other LocalScans so
+                // multi-root ArchiveUpload sits any number of slots ahead.
+                Operation* nextNonScan = nullptr;
+                for (std::size_t lookahead = item.queueIndex + 1; lookahead < queue.size(); ++lookahead)
+                {
+                    auto* candidate = queue[lookahead].second.get();
+                    if (candidate->type() != SharedData::OperationType::LocalScan)
+                    {
+                        nextNonScan = candidate;
+                        break;
+                    }
+                }
                 if (next && next->type() == SharedData::OperationType::BulkUpload)
                 {
                     auto* scan = static_cast<LocalScanOperation*>(operation.get());
                     static_cast<BulkUploadOperation*>(next)->setScanResult(scan->ejectEntries(), scan->totalBytes());
+                }
+                else if (nextNonScan && nextNonScan->type() == SharedData::OperationType::ArchiveUpload)
+                {
+                    auto* scan = static_cast<LocalScanOperation*>(operation.get());
+                    static_cast<ArchiveUploadOperation*>(nextNonScan)->setScanResultForRoot(
+                        scan->localPath(), scan->ejectEntries(), scan->totalBytes()
+                    );
                 }
                 else
                 {
@@ -806,19 +845,19 @@ std::expected<void, Operation::Error> OperationQueue::addDownloadOperation(
     }
     else if (result->isDirectory())
     {
+        // operationId is assigned to BulkDownload so the frontend's completion callback
+        // (registered on operationId) fires only after all files are fully downloaded,
+        // not when the preceding scan finishes.
+        const auto scanId = Ids::generateOperationId();
         auto scan = std::make_unique<ScanOperation>(
             sftp,
             ScanOperation::ScanOperationOptions{
-                .progressCallback = makeScanProgressCallback("onScanProgress", operationId),
+                .progressCallback = makeScanProgressCallback("onScanProgress", scanId),
                 .remotePath = remotePath,
                 .futureTimeout = std::chrono::seconds{5},
             }
         );
 
-        // operationId is assigned to BulkDownload so the frontend's completion callback
-        // (registered on operationId) fires only after all files are fully downloaded,
-        // not when the preceding scan finishes.
-        const auto scanId = Ids::generateOperationId();
         auto bulk = std::make_unique<BulkDownloadOperation>(
             sftp,
             BulkDownloadOperation::BulkDownloadOperationOptions{
@@ -944,6 +983,21 @@ std::expected<void, Operation::Error> OperationQueue::addArchiveDownloadOperatio
         if (entry.type == SharedData::FileType::Regular)
             totalPayloadBytes += entry.size;
     }
+    const auto rootCount = entries.size();
+
+    // Collect each directory root's full remote path so we can enqueue a
+    // preceding ScanOperation per root. The archive operation consumes those
+    // scans' results via setScanResultForRoot and never recurses itself, so
+    // scan work is always visible as a separate queue card.
+    std::vector<std::filesystem::path> directoryRootPaths;
+    for (auto const& entry : entries)
+    {
+        if (entry.type == SharedData::FileType::Directory)
+        {
+            const auto rootFullPath = entry.fullPath.empty() ? entry.path : entry.fullPath;
+            directoryRootPaths.push_back(rootFullPath);
+        }
+    }
 
     ArchiveDownloadOperation::Options opts{};
     opts.entries = std::move(entries);
@@ -983,15 +1037,44 @@ std::expected<void, Operation::Error> OperationQueue::addArchiveDownloadOperatio
 
     auto& targetQueue =
         (mode == SharedData::OperationMode::PriorityQueued) ? priorityOperations_ : operations_;
+
+    // Scans first so the dispatcher can hand each scan's results to the
+    // archive op sitting one-or-more slots ahead.  They share a single queue
+    // position (adjacency scan → ... → scan → archive), which the scan-
+    // completion handler in workQueue walks past to reach the archive op.
+    for (auto const& rootPath : directoryRootPaths)
+    {
+        const auto scanId = Ids::generateOperationId();
+        auto scan = std::make_unique<ScanOperation>(
+            sftp,
+            ScanOperation::ScanOperationOptions{
+                .progressCallback = makeScanProgressCallback("onScanProgress", scanId),
+                .remotePath = rootPath,
+                .futureTimeout = sftpOpts_.operationTimeout.value_or(defaultFutureTimeout),
+            }
+        );
+        targetQueue.emplace_back(scanId, std::move(scan));
+        hub_->callRemote(
+            rpcName("onOperationAdded"),
+            SharedData::OperationAdded{
+                .operationId = scanId,
+                .type = SharedData::OperationType::Scan,
+                .mode = mode,
+                .remotePath = rootPath,
+            }
+        );
+    }
+
     targetQueue.emplace_back(
         operationId, std::make_unique<ArchiveDownloadOperation>(sftp, std::move(opts))
     );
 
     Log::info(
-        "OperationQueue::{}::onOperationAdded (ArchiveDownload, {} entries, {} bytes)",
+        "OperationQueue::{}::onOperationAdded (ArchiveDownload, {} entries, {} bytes, {} pre-scans)",
         sessionId_.value(),
-        opts.entries.size(),
-        totalPayloadBytes
+        rootCount,
+        totalPayloadBytes,
+        directoryRootPaths.size()
     );
     hub_->callRemote(
         rpcName("onOperationAdded"),
@@ -999,7 +1082,7 @@ std::expected<void, Operation::Error> OperationQueue::addArchiveDownloadOperatio
             .operationId = operationId,
             .type = SharedData::OperationType::ArchiveDownload,
             .mode = mode,
-            .insertRefresh = false,
+            .insertRefresh = true,
             .totalBytes = totalPayloadBytes,
             .localPath = localArchivePath,
         }
@@ -1041,6 +1124,18 @@ std::expected<void, Operation::Error> OperationQueue::addArchiveUploadOperation(
             estimatedTotalBytes += size;
     }
 
+    // Local directory roots get a visible LocalScanOperation each; the
+    // archive op itself never recurses and instead consumes each scan's
+    // output via setScanResultForRoot — keyed by the root's local path.
+    std::vector<std::filesystem::path> directoryRootPaths;
+    for (auto const& localPath : localPaths)
+    {
+        std::error_code isDirErr{};
+        if (std::filesystem::is_directory(localPath, isDirErr))
+            directoryRootPaths.push_back(localPath);
+    }
+    const auto rootCount = localPaths.size();
+
     ArchiveUploadOperation::Options opts{};
     opts.localPaths = std::move(localPaths);
     opts.remoteArchivePath = remoteArchivePath;
@@ -1078,15 +1173,41 @@ std::expected<void, Operation::Error> OperationQueue::addArchiveUploadOperation(
 
     auto& targetQueue =
         (mode == SharedData::OperationMode::PriorityQueued) ? priorityOperations_ : operations_;
+
+    // Scans first: the scan-complete dispatcher walks past subsequent scans
+    // to reach this archive op and feeds each LocalScan's slice into its
+    // setScanResultForRoot.  Queue layout: [LocalScan...] ... [ArchiveUpload].
+    for (auto const& rootPath : directoryRootPaths)
+    {
+        const auto scanId = Ids::generateOperationId();
+        auto scan = std::make_unique<LocalScanOperation>(
+            LocalScanOperation::ScanOperationOptions{
+                .progressCallback = makeScanProgressCallback("onLocalScanProgress", scanId),
+                .localPath = rootPath,
+            }
+        );
+        targetQueue.emplace_back(scanId, std::move(scan));
+        hub_->callRemote(
+            rpcName("onOperationAdded"),
+            SharedData::OperationAdded{
+                .operationId = scanId,
+                .type = SharedData::OperationType::LocalScan,
+                .mode = mode,
+                .localPath = rootPath,
+            }
+        );
+    }
+
     targetQueue.emplace_back(
         operationId, std::make_unique<ArchiveUploadOperation>(sftp, std::move(opts))
     );
 
     Log::info(
-        "OperationQueue::{}::onOperationAdded (ArchiveUpload, {} paths, ~{} bytes)",
+        "OperationQueue::{}::onOperationAdded (ArchiveUpload, {} paths, ~{} bytes, {} pre-scans)",
         sessionId_.value(),
-        opts.localPaths.size(),
-        estimatedTotalBytes
+        rootCount,
+        estimatedTotalBytes,
+        directoryRootPaths.size()
     );
     hub_->callRemote(
         rpcName("onOperationAdded"),
@@ -1094,7 +1215,7 @@ std::expected<void, Operation::Error> OperationQueue::addArchiveUploadOperation(
             .operationId = operationId,
             .type = SharedData::OperationType::ArchiveUpload,
             .mode = mode,
-            .insertRefresh = false,
+            .insertRefresh = true,
             .totalBytes = estimatedTotalBytes,
             .remotePath = remoteArchivePath,
         }

--- a/backend/source/backend/sftp/upload_operation.cpp
+++ b/backend/source/backend/sftp/upload_operation.cpp
@@ -617,7 +617,29 @@ std::expected<void, Operation::Error> UploadOperation::prepare()
 
 std::expected<void, UploadOperation::Error> UploadOperation::prepareInStrand()
 {
-    return openOrAdoptFileInStrand();
+    if (auto result = openOrAdoptFileInStrand(); !result.has_value())
+        return std::unexpected(result.error());
+
+    auto stream = fileStream_.lock();
+    if (!stream)
+    {
+        Log::error("UploadOperation: File stream expired after open.");
+        return std::unexpected(Error{.type = ErrorType::FileStreamExpired});
+    }
+
+    buffer_ = sftp_->bufferProvider().leaseForTransfer(totalSize_, stream->writeLengthLimit());
+    if (buffer_.empty())
+    {
+        Log::error("UploadOperation: No transfer buffer available from pool.");
+        return std::unexpected(Error{
+            .type = ErrorType::SftpError,
+            .sftpError = SecureShell::SftpError{
+                .message = "No buffer available from pool",
+                .wrapperError = SecureShell::WrapperErrors::BufferUnavailable,
+            },
+        });
+    }
+    return {};
 }
 
 std::expected<void, UploadOperation::Error> UploadOperation::cancel(bool adoptCancelState)

--- a/backend/test/backend/test_archive_download_operation.hpp
+++ b/backend/test/backend/test_archive_download_operation.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <backend/sftp/archive_download_operation.hpp>
+#include <backend/sftp/scan_operation.hpp>
 #include "real_server_tests.hpp"
 #include "archive_test_helpers.hpp"
 
@@ -40,6 +41,33 @@ namespace Test
                     return last;
             }
             return last;
+        }
+
+        /**
+         * @brief Run a remote ScanOperation to completion and return its flat
+         *        walker entry vector plus cumulative totalBytes, matching what
+         *        OperationQueue's dispatcher hands to setScanResultForRoot.
+         */
+        struct ScanBundle
+        {
+            std::vector<SharedData::DirectoryEntry> entries{};
+            std::uint64_t totalBytes{0u};
+        };
+        static ScanBundle runScan(SecureShell::SftpSession& sftp, std::filesystem::path const& path)
+        {
+            ScanOperation scan{
+                sftp,
+                ScanOperation::ScanOperationOptions{.remotePath = path},
+            };
+            while (true)
+            {
+                const auto step = scan.work();
+                EXPECT_TRUE(step.has_value()) << "scan failed";
+                if (!step.has_value() || step.value() == ScanOperation::WorkStatus::Complete)
+                    break;
+            }
+            const auto totalBytes = scan.totalBytes();
+            return ScanBundle{.entries = std::move(scan).ejectEntries(), .totalBytes = totalBytes};
         }
     };
 
@@ -203,7 +231,35 @@ namespace Test
         CREATE_SERVER_AND_JOINER(sftpServer);
         auto [_, sftp] = createSftpSession(serverStartResult->port);
 
+        const std::filesystem::path rootPath = "/home/test/Documents";
+        auto scan = runScan(*sftp, rootPath);
+
         const auto archivePath = archiveDir_.path() / "documents.tar";
+        ArchiveDownloadOperation operation{
+            *sftp,
+            {
+                .entries = {makeDirectoryEntry(rootPath)},
+                .localArchivePath = archivePath,
+                .compression = TarArchive::Compression::None,
+            }};
+        operation.setScanResultForRoot(rootPath, std::move(scan.entries), scan.totalBytes);
+        ASSERT_TRUE(runToCompletion(operation).has_value());
+
+        const auto entries = recoverArchiveEntries(archivePath);
+        EXPECT_NE(findEntry(entries, "Documents/doc1.txt"), nullptr);
+        EXPECT_NE(findEntry(entries, "Documents/doc2.txt"), nullptr);
+
+        const auto* doc1 = findEntry(entries, "Documents/doc1.txt");
+        ASSERT_NE(doc1, nullptr);
+        EXPECT_EQ(doc1->contents, "Document 1 content");
+    }
+
+    TEST_F(ArchiveDownloadOperationTests, DirectoryRootWithoutPrescanErrors)
+    {
+        CREATE_SERVER_AND_JOINER(sftpServer);
+        auto [_, sftp] = createSftpSession(serverStartResult->port);
+
+        const auto archivePath = archiveDir_.path() / "missing_scan.tar";
         ArchiveDownloadOperation operation{
             *sftp,
             {
@@ -211,16 +267,138 @@ namespace Test
                 .localArchivePath = archivePath,
                 .compression = TarArchive::Compression::None,
             }};
+        // Intentionally skip setScanResultForRoot — the op must not
+        // self-recurse; it has to surface an ImplementationError instead.
+        const auto result = runToCompletion(operation);
+        ASSERT_FALSE(result.has_value());
+        EXPECT_EQ(result.error().type, ArchiveDownloadOperation::ErrorType::ImplementationError);
+    }
+
+    TEST_F(ArchiveDownloadOperationTests, UnrelatedPrescanRootStillFailsMatchingDirectory)
+    {
+        CREATE_SERVER_AND_JOINER(sftpServer);
+        auto [_, sftp] = createSftpSession(serverStartResult->port);
+
+        // Pre-scan Pictures but then ask the archive to pack Documents —
+        // the setScanResultForRoot call is keyed by the mismatched path and
+        // must not satisfy the Documents root, which is still missing.
+        auto pictures = runScan(*sftp, "/home/test/Pictures");
+
+        const auto archivePath = archiveDir_.path() / "wrong_key.tar";
+        ArchiveDownloadOperation operation{
+            *sftp,
+            {
+                .entries = {makeDirectoryEntry("/home/test/Documents")},
+                .localArchivePath = archivePath,
+                .compression = TarArchive::Compression::None,
+            }};
+        operation.setScanResultForRoot(
+            "/home/test/Pictures", std::move(pictures.entries), pictures.totalBytes
+        );
+        const auto result = runToCompletion(operation);
+        ASSERT_FALSE(result.has_value());
+        EXPECT_EQ(result.error().type, ArchiveDownloadOperation::ErrorType::ImplementationError);
+    }
+
+    TEST_F(ArchiveDownloadOperationTests, MultipleDirectoryRootsAggregateUnderBasenames)
+    {
+        CREATE_SERVER_AND_JOINER(sftpServer);
+        auto [_, sftp] = createSftpSession(serverStartResult->port);
+
+        auto documents = runScan(*sftp, "/home/test/Documents");
+        auto pictures = runScan(*sftp, "/home/test/Pictures");
+
+        const auto archivePath = archiveDir_.path() / "two_roots.tar";
+        ArchiveDownloadOperation operation{
+            *sftp,
+            {
+                .entries =
+                    {
+                        makeDirectoryEntry("/home/test/Documents"),
+                        makeDirectoryEntry("/home/test/Pictures"),
+                    },
+                .localArchivePath = archivePath,
+                .compression = TarArchive::Compression::None,
+            }};
+        operation.setScanResultForRoot(
+            "/home/test/Documents", std::move(documents.entries), documents.totalBytes
+        );
+        operation.setScanResultForRoot(
+            "/home/test/Pictures", std::move(pictures.entries), pictures.totalBytes
+        );
         ASSERT_TRUE(runToCompletion(operation).has_value());
 
         const auto entries = recoverArchiveEntries(archivePath);
-        // Directory header + doc1.txt + doc2.txt.
         EXPECT_NE(findEntry(entries, "Documents/doc1.txt"), nullptr);
         EXPECT_NE(findEntry(entries, "Documents/doc2.txt"), nullptr);
+        EXPECT_NE(findEntry(entries, "Pictures/image1.png"), nullptr);
+        EXPECT_NE(findEntry(entries, "Pictures/image2.jpg"), nullptr);
+    }
 
-        const auto* doc1 = findEntry(entries, "Documents/doc1.txt");
-        ASSERT_NE(doc1, nullptr);
-        EXPECT_EQ(doc1->contents, "Document 1 content");
+    TEST_F(ArchiveDownloadOperationTests, MixedRegularAndDirectoryRoots)
+    {
+        CREATE_SERVER_AND_JOINER(sftpServer);
+        auto [_, sftp] = createSftpSession(serverStartResult->port);
+
+        auto documents = runScan(*sftp, "/home/test/Documents");
+
+        const auto archivePath = archiveDir_.path() / "mixed_roots.tar";
+        ArchiveDownloadOperation operation{
+            *sftp,
+            {
+                .entries =
+                    {
+                        makeFileEntry("/home/test/file1.txt", 17u),
+                        makeDirectoryEntry("/home/test/Documents"),
+                    },
+                .localArchivePath = archivePath,
+                .compression = TarArchive::Compression::None,
+            }};
+        // Regular-file roots never receive a setScanResultForRoot call — only
+        // the directory root does. This asserts the op still succeeds in that
+        // mixed configuration and doesn't treat file1.txt as missing-scan.
+        operation.setScanResultForRoot(
+            "/home/test/Documents", std::move(documents.entries), documents.totalBytes
+        );
+        ASSERT_TRUE(runToCompletion(operation).has_value());
+
+        const auto entries = recoverArchiveEntries(archivePath);
+        const auto* file1 = findEntry(entries, "file1.txt");
+        ASSERT_NE(file1, nullptr);
+        EXPECT_EQ(file1->contents, "Fake file content");
+        EXPECT_NE(findEntry(entries, "Documents/doc1.txt"), nullptr);
+        EXPECT_NE(findEntry(entries, "Documents/doc2.txt"), nullptr);
+    }
+
+    TEST_F(ArchiveDownloadOperationTests, NestedSubdirectoryPreservesRelativePath)
+    {
+        CREATE_SERVER_AND_JOINER(sftpServer);
+        auto [_, sftp] = createSftpSession(serverStartResult->port);
+
+        // /var contains the subdirectory 'log', which itself contains files.
+        // This exercises the tar-path composition through fullPathRelative:
+        // a deeper-than-one-level entry must come out as 'var/log/syslog',
+        // not 'var/syslog'.
+        auto scan = runScan(*sftp, "/var");
+
+        const auto archivePath = archiveDir_.path() / "var_tree.tar";
+        ArchiveDownloadOperation operation{
+            *sftp,
+            {
+                .entries = {makeDirectoryEntry("/var")},
+                .localArchivePath = archivePath,
+                .compression = TarArchive::Compression::None,
+            }};
+        operation.setScanResultForRoot("/var", std::move(scan.entries), scan.totalBytes);
+        ASSERT_TRUE(runToCompletion(operation).has_value());
+
+        const auto entries = recoverArchiveEntries(archivePath);
+        const auto* syslog = findEntry(entries, "var/log/syslog");
+        ASSERT_NE(syslog, nullptr);
+        EXPECT_EQ(syslog->contents, "Fake syslog content");
+        const auto* authLog = findEntry(entries, "var/log/auth.log");
+        ASSERT_NE(authLog, nullptr);
+        EXPECT_EQ(authLog->contents, "Fake auth.log content");
     }
 
     TEST_F(ArchiveDownloadOperationTests, LargeFilePassesThrough)

--- a/backend/test/backend/test_archive_download_operation.hpp
+++ b/backend/test/backend/test_archive_download_operation.hpp
@@ -232,18 +232,16 @@ namespace Test
         ArchiveDownloadOperation operation{
             *sftp,
             {
-                .entries = {makeFileEntry("/home/test/large.txt", 1024u * 1024u)},
+                .entries = {makeFileEntry("/home/test/large.txt", 65536u)},
                 .localArchivePath = archivePath,
                 .compression = TarArchive::Compression::None,
             }};
-        // 1 MiB / 64 KiB chunk = 16 reads, plus header/finalise work.  A
-        // generous budget keeps the test robust to strand scheduling jitter.
         ASSERT_TRUE(runToCompletion(operation, 2000).has_value());
 
         const auto entries = recoverArchiveEntries(archivePath);
         ASSERT_EQ(entries.size(), 1u);
         EXPECT_EQ(entries[0].path, "large.txt");
-        EXPECT_EQ(entries[0].contents.size(), 1024u * 1024u);
+        EXPECT_EQ(entries[0].contents.size(), 65536u);
     }
 
     TEST_F(ArchiveDownloadOperationTests, FilepartAbsentAfterCompletion)

--- a/backend/test/backend/test_archive_upload_operation.hpp
+++ b/backend/test/backend/test_archive_upload_operation.hpp
@@ -2,6 +2,7 @@
 
 #include <backend/sftp/archive_upload_operation.hpp>
 #include <backend/sftp/download_operation.hpp>
+#include <backend/sftp/local_scan_operation.hpp>
 #include "real_server_tests.hpp"
 #include "archive_test_helpers.hpp"
 
@@ -55,6 +56,32 @@ namespace Test
                     return last;
             }
             return last;
+        }
+
+        /**
+         * @brief Run a LocalScanOperation to completion and return the walker
+         *        entry vector plus cumulative totalBytes, matching what the
+         *        OperationQueue dispatcher hands to setScanResultForRoot.
+         */
+        struct LocalScanBundle
+        {
+            std::vector<SharedData::DirectoryEntry> entries{};
+            std::uint64_t totalBytes{0u};
+        };
+        static LocalScanBundle runLocalScan(std::filesystem::path const& path)
+        {
+            LocalScanOperation scan{
+                LocalScanOperation::ScanOperationOptions{.localPath = path},
+            };
+            while (true)
+            {
+                const auto step = scan.work();
+                EXPECT_TRUE(step.has_value()) << "local scan failed";
+                if (!step.has_value() || step.value() == LocalScanOperation::WorkStatus::Complete)
+                    break;
+            }
+            const auto totalBytes = scan.totalBytes();
+            return LocalScanBundle{.entries = scan.ejectEntries(), .totalBytes = totalBytes};
         }
 
         /**
@@ -237,6 +264,8 @@ namespace Test
         CREATE_SERVER_AND_JOINER(sftpServer);
         auto [_, sftp] = createSftpSession(serverStartResult->port);
 
+        auto scan = runLocalScan(srcDir_.path());
+
         const std::filesystem::path remoteArchive = "/home/test/tree.tar";
         ArchiveUploadOperation operation{
             *sftp,
@@ -246,6 +275,7 @@ namespace Test
                 .compression = TarArchive::Compression::None,
                 .mayOverwrite = true,
             }};
+        operation.setScanResultForRoot(srcDir_.path(), std::move(scan.entries), scan.totalBytes);
         ASSERT_TRUE(runToCompletion(operation).has_value());
 
         const auto pulled = pullRemoteArchive(*sftp, remoteArchive, "tree.tar");
@@ -255,6 +285,154 @@ namespace Test
         EXPECT_NE(findEntry(entries, rootName + "/alpha.txt"), nullptr);
         EXPECT_NE(findEntry(entries, rootName + "/beta.txt"), nullptr);
         EXPECT_NE(findEntry(entries, rootName + "/nested/deep.txt"), nullptr);
+
+        const auto* deep = findEntry(entries, rootName + "/nested/deep.txt");
+        ASSERT_NE(deep, nullptr);
+        EXPECT_EQ(deep->contents, "deep payload");
+    }
+
+    TEST_F(ArchiveUploadOperationTests, DirectoryRootWithoutPrescanErrors)
+    {
+        CREATE_SERVER_AND_JOINER(sftpServer);
+        auto [_, sftp] = createSftpSession(serverStartResult->port);
+
+        ArchiveUploadOperation operation{
+            *sftp,
+            {
+                .localPaths = {srcDir_.path()},
+                .remoteArchivePath = "/home/test/missing_scan.tar",
+                .compression = TarArchive::Compression::None,
+                .mayOverwrite = true,
+            }};
+        // No setScanResultForRoot — the op must not self-recurse; it has to
+        // surface an ImplementationError like its download counterpart.
+        const auto result = runToCompletion(operation);
+        ASSERT_FALSE(result.has_value());
+        EXPECT_EQ(result.error().type, ArchiveUploadOperation::ErrorType::ImplementationError);
+    }
+
+    TEST_F(ArchiveUploadOperationTests, UnrelatedPrescanRootStillFailsMatchingDirectory)
+    {
+        CREATE_SERVER_AND_JOINER(sftpServer);
+        auto [_, sftp] = createSftpSession(serverStartResult->port);
+
+        // Create a second directory tree distinct from srcDir_.  The scan is
+        // keyed on that path; the archive asks to pack srcDir_ instead, so
+        // the real root is still missing its scan and must error.
+        Utility::TemporaryDirectory otherDir{programDirectory / "temp", true};
+        writeFile(otherDir.path() / "unrelated.txt", "unrelated");
+        auto otherScan = runLocalScan(otherDir.path());
+
+        ArchiveUploadOperation operation{
+            *sftp,
+            {
+                .localPaths = {srcDir_.path()},
+                .remoteArchivePath = "/home/test/wrong_key.tar",
+                .compression = TarArchive::Compression::None,
+                .mayOverwrite = true,
+            }};
+        operation.setScanResultForRoot(
+            otherDir.path(), std::move(otherScan.entries), otherScan.totalBytes
+        );
+        const auto result = runToCompletion(operation);
+        ASSERT_FALSE(result.has_value());
+        EXPECT_EQ(result.error().type, ArchiveUploadOperation::ErrorType::ImplementationError);
+    }
+
+    TEST_F(ArchiveUploadOperationTests, MultipleDirectoryRootsAggregateUnderBasenames)
+    {
+        CREATE_SERVER_AND_JOINER(sftpServer);
+        auto [_, sftp] = createSftpSession(serverStartResult->port);
+
+        Utility::TemporaryDirectory firstDir{programDirectory / "temp", true};
+        Utility::TemporaryDirectory secondDir{programDirectory / "temp", true};
+        writeFile(firstDir.path() / "one.txt", "one payload");
+        writeFile(secondDir.path() / "two.txt", "two payload");
+
+        auto firstScan = runLocalScan(firstDir.path());
+        auto secondScan = runLocalScan(secondDir.path());
+
+        const std::filesystem::path remoteArchive = "/home/test/two_roots_up.tar";
+        ArchiveUploadOperation operation{
+            *sftp,
+            {
+                .localPaths = {firstDir.path(), secondDir.path()},
+                .remoteArchivePath = remoteArchive,
+                .compression = TarArchive::Compression::None,
+                .mayOverwrite = true,
+            }};
+        operation.setScanResultForRoot(
+            firstDir.path(), std::move(firstScan.entries), firstScan.totalBytes
+        );
+        operation.setScanResultForRoot(
+            secondDir.path(), std::move(secondScan.entries), secondScan.totalBytes
+        );
+        ASSERT_TRUE(runToCompletion(operation).has_value());
+
+        const auto pulled = pullRemoteArchive(*sftp, remoteArchive, "two_roots_up.tar");
+        const auto entries = recoverArchiveEntries(pulled);
+        const auto firstName = firstDir.path().filename().generic_string();
+        const auto secondName = secondDir.path().filename().generic_string();
+        EXPECT_NE(findEntry(entries, firstName + "/one.txt"), nullptr);
+        EXPECT_NE(findEntry(entries, secondName + "/two.txt"), nullptr);
+    }
+
+    TEST_F(ArchiveUploadOperationTests, MixedRegularAndDirectoryRoots)
+    {
+        CREATE_SERVER_AND_JOINER(sftpServer);
+        auto [_, sftp] = createSftpSession(serverStartResult->port);
+
+        auto scan = runLocalScan(srcDir_.path());
+
+        const std::filesystem::path topFile = srcDir_.path() / "alpha.txt";
+        const std::filesystem::path remoteArchive = "/home/test/mixed_up.tar";
+        ArchiveUploadOperation operation{
+            *sftp,
+            {
+                // A regular-file root (no scan needed) alongside a directory
+                // root (which does need a scan) — the op must succeed and
+                // must not mis-flag the file as missing-scan.
+                .localPaths = {topFile, srcDir_.path()},
+                .remoteArchivePath = remoteArchive,
+                .compression = TarArchive::Compression::None,
+                .mayOverwrite = true,
+            }};
+        operation.setScanResultForRoot(srcDir_.path(), std::move(scan.entries), scan.totalBytes);
+        ASSERT_TRUE(runToCompletion(operation).has_value());
+
+        const auto pulled = pullRemoteArchive(*sftp, remoteArchive, "mixed_up.tar");
+        const auto entries = recoverArchiveEntries(pulled);
+
+        const auto rootName = srcDir_.path().filename().generic_string();
+        EXPECT_NE(findEntry(entries, "alpha.txt"), nullptr);
+        EXPECT_NE(findEntry(entries, rootName + "/beta.txt"), nullptr);
+    }
+
+    TEST_F(ArchiveUploadOperationTests, NestedSubdirectoryPreservesRelativePath)
+    {
+        CREATE_SERVER_AND_JOINER(sftpServer);
+        auto [_, sftp] = createSftpSession(serverStartResult->port);
+
+        // srcDir_ already contains `nested/deep.txt` via SetUp(); this is
+        // the upload-side fullPathRelative check — a grandchild must land
+        // at <root>/nested/deep.txt, not <root>/deep.txt.
+        auto scan = runLocalScan(srcDir_.path());
+
+        const std::filesystem::path remoteArchive = "/home/test/nested_up.tar";
+        ArchiveUploadOperation operation{
+            *sftp,
+            {
+                .localPaths = {srcDir_.path()},
+                .remoteArchivePath = remoteArchive,
+                .compression = TarArchive::Compression::None,
+                .mayOverwrite = true,
+            }};
+        operation.setScanResultForRoot(srcDir_.path(), std::move(scan.entries), scan.totalBytes);
+        ASSERT_TRUE(runToCompletion(operation).has_value());
+
+        const auto pulled = pullRemoteArchive(*sftp, remoteArchive, "nested_up.tar");
+        const auto entries = recoverArchiveEntries(pulled);
+        const auto rootName = srcDir_.path().filename().generic_string();
 
         const auto* deep = findEntry(entries, rootName + "/nested/deep.txt");
         ASSERT_NE(deep, nullptr);

--- a/backend/test/backend/test_download_operation.hpp
+++ b/backend/test/backend/test_download_operation.hpp
@@ -484,7 +484,7 @@ namespace Test
         ASSERT_EQ(workStatus, DownloadOperation::WorkStatus::Complete);
 
         ASSERT_TRUE(std::filesystem::exists(localPath));
-        EXPECT_EQ(std::filesystem::file_size(localPath), 1024u * 1024u);
+        EXPECT_EQ(std::filesystem::file_size(localPath), 65536u);
     }
 
     // ---- Symlink handling --------------------------------------------------

--- a/backend/test/backend/test_scan_operation.hpp
+++ b/backend/test/backend/test_scan_operation.hpp
@@ -167,7 +167,7 @@ namespace Test
         auto const* largeEntry = findEntryNamed(entries, "large.txt");
         ASSERT_NE(largeEntry, nullptr);
         EXPECT_EQ(largeEntry->type, SharedData::FileType::Regular);
-        EXPECT_EQ(largeEntry->size, 1024u * 1024u);
+        EXPECT_EQ(largeEntry->size, 65536u);
 
         auto const* dirEntry = findEntryNamed(entries, "Documents");
         ASSERT_NE(dirEntry, nullptr);

--- a/frontend/include/frontend/session_components/operation_queue/displayed_bulk_operation.hpp
+++ b/frontend/include/frontend/session_components/operation_queue/displayed_bulk_operation.hpp
@@ -113,9 +113,17 @@ struct DisplayedBulkOperation : public OperationCard<DisplayedBulkOperation>
                 span{
                     class_ = "opq-status-text opq-status-count"
                 }(
-                    observe(fileCurrentIndex, fileCount),
+                    observe(fileCurrentIndex, fileCount, state_),
                     [this](){
-                        return fmt::format("{}/{}", fileCurrentIndex.value(), fileCount.value());
+                        // On successful completion, pin the numerator to the
+                        // total so a dropped or late terminal progress tick
+                        // can't leave the card stuck at (N-1)/N.
+                        const auto finished = state_.value() == SharedData::OperationState::Completed ||
+                            state_.value() == SharedData::OperationState::PartialSuccess;
+                        const auto current = (finished && fileCount.value() > 0)
+                            ? fileCount.value()
+                            : fileCurrentIndex.value();
+                        return fmt::format("{}/{}", current, fileCount.value());
                     }
                 ),
                 span{

--- a/frontend/source/frontend/file_explorer/local_side_model.cpp
+++ b/frontend/source/frontend/file_explorer/local_side_model.cpp
@@ -955,7 +955,11 @@ void LocalSideModel::uploadItemsConfirmed(
         });
     };
 
-    auto flushAccepted = [this, &accepted, overwriteAlways]() {
+    // Every entry in `accepted` is either a non-existing destination or an
+    // item the user explicitly approved for overwrite (Yes / All); the "No"
+    // and "None" branches skip the push.  So allowOverwrite=true at flush
+    // time is semantically correct regardless of the overwriteAlways flag.
+    auto flushAccepted = [this, &accepted]() {
         if (accepted->empty())
             return;
         // Single-file fast path: a one-entry flush skips the bulk machinery
@@ -979,7 +983,7 @@ void LocalSideModel::uploadItemsConfirmed(
             enqueueSingleUpload(
                 NuiFileExplorer::Item{remoteEntry},
                 NuiFileExplorer::Item{localEntry},
-                /*allowOverwrite=*/overwriteAlways,
+                /*allowOverwrite=*/true,
                 /*insertRefresh=*/true
             );
             accepted->clear();
@@ -987,7 +991,7 @@ void LocalSideModel::uploadItemsConfirmed(
         }
         operationQueue_->enqueueBulkUpload(
             std::move(*accepted),
-            /*allowOverwrite*/ overwriteAlways,
+            /*allowOverwrite*/ true,
             /*insertRefresh*/ true,
             SharedData::OperationMode::Queued,
             /*onEachComplete*/ {},

--- a/frontend/source/frontend/file_explorer/remote_side_model.cpp
+++ b/frontend/source/frontend/file_explorer/remote_side_model.cpp
@@ -700,7 +700,11 @@ void RemoteSideModel::downloadItemsConfirmed(
         });
     };
 
-    auto flushAccepted = [this, &accepted, overwriteAlways]() {
+    // Every entry in `accepted` is either a non-existing destination or an
+    // item the user explicitly approved for overwrite (Yes / All); the "No"
+    // and "None" branches skip the push.  So allowOverwrite=true at flush
+    // time is semantically correct regardless of the overwriteAlways flag.
+    auto flushAccepted = [this, &accepted]() {
         if (accepted->empty())
             return;
         // Single-file fast path: a one-entry flush skips the bulk machinery
@@ -722,7 +726,7 @@ void RemoteSideModel::downloadItemsConfirmed(
             enqueueSingleDownload(
                 NuiFileExplorer::Item{remoteEntry},
                 NuiFileExplorer::Item{localEntry},
-                /*allowOverwrite=*/overwriteAlways,
+                /*allowOverwrite=*/true,
                 /*insertRefresh=*/true
             );
             accepted->clear();
@@ -734,7 +738,7 @@ void RemoteSideModel::downloadItemsConfirmed(
         // RPCs with one.
         operationQueue_->enqueueBulkDownload(
             std::move(*accepted),
-            /*allowOverwrite*/ overwriteAlways,
+            /*allowOverwrite*/ true,
             /*insertRefresh*/ true,
             SharedData::OperationMode::Queued,
             /*onEachComplete*/ {},

--- a/ssh/include/ssh/async/buffer_provider.hpp
+++ b/ssh/include/ssh/async/buffer_provider.hpp
@@ -1,0 +1,434 @@
+#pragma once
+
+#include <algorithm>
+#include <array>
+#include <cstddef>
+#include <memory>
+#include <mutex>
+#include <tuple>
+#include <type_traits>
+#include <vector>
+
+namespace SecureShell
+{
+    /**
+     * @brief Size categories for pooled SFTP transfer buffers.
+     */
+    enum class BufferCategory
+    {
+        Tiny,
+        Small,
+        Medium,
+        Large,
+        Max,
+    };
+
+    /**
+     * @brief Byte size associated with each category.
+     */
+    constexpr std::size_t bufferCategorySize(BufferCategory category) noexcept
+    {
+        switch (category)
+        {
+            case BufferCategory::Tiny:
+                return 1ull * 1024ull;
+            case BufferCategory::Small:
+                return 4ull * 1024ull;
+            case BufferCategory::Medium:
+                return 16ull * 1024ull;
+            case BufferCategory::Large:
+                return 64ull * 1024ull;
+            case BufferCategory::Max:
+                return 256ull * 1024ull;
+        }
+        return 0u;
+    }
+
+    /**
+     * @brief Storage kind per category. Tiny/Small are inline std::array; larger categories use std::vector.
+     */
+    template <BufferCategory Category>
+    struct CategoryStorage;
+
+    template <>
+    struct CategoryStorage<BufferCategory::Tiny>
+    {
+        using type = std::array<char, bufferCategorySize(BufferCategory::Tiny)>;
+    };
+    template <>
+    struct CategoryStorage<BufferCategory::Small>
+    {
+        using type = std::array<char, bufferCategorySize(BufferCategory::Small)>;
+    };
+    template <>
+    struct CategoryStorage<BufferCategory::Medium>
+    {
+        using type = std::vector<char>;
+    };
+    template <>
+    struct CategoryStorage<BufferCategory::Large>
+    {
+        using type = std::vector<char>;
+    };
+    template <>
+    struct CategoryStorage<BufferCategory::Max>
+    {
+        using type = std::vector<char>;
+    };
+
+    /**
+     * @brief Variadic slot descriptor used to configure a BufferProvider.
+     */
+    template <BufferCategory Category, std::size_t Count>
+    struct CategorySlots
+    {
+        static constexpr BufferCategory category = Category;
+        static constexpr std::size_t count = Count;
+        static_assert(Count >= 1u, "each category needs at least one slot");
+    };
+
+    /**
+     * @brief A single bucket of pre-allocated buffers for one category.
+     */
+    template <BufferCategory Category, std::size_t Count>
+    struct TypedBucket
+    {
+        using Storage = typename CategoryStorage<Category>::type;
+
+        std::array<Storage, Count> slots{};
+        std::array<bool, Count> taken{};
+
+        TypedBucket()
+        {
+            if constexpr (std::is_same_v<Storage, std::vector<char>>)
+            {
+                for (auto& slot : slots)
+                    slot.resize(bufferCategorySize(Category));
+            }
+        }
+    };
+
+    class IBufferProvider;
+
+    /**
+     * @brief Move-only RAII handle for a pooled buffer slot. Returns the slot to the provider on destruction.
+     */
+    class BufferLease
+    {
+      public:
+        BufferLease() noexcept = default;
+        ~BufferLease();
+
+        BufferLease(BufferLease&& other) noexcept;
+        BufferLease& operator=(BufferLease&& other) noexcept;
+        BufferLease(BufferLease const&) = delete;
+        BufferLease& operator=(BufferLease const&) = delete;
+
+        char* data() noexcept
+        {
+            return data_;
+        }
+        char const* data() const noexcept
+        {
+            return data_;
+        }
+        std::size_t size() const noexcept
+        {
+            return size_;
+        }
+        std::size_t capacity() const noexcept
+        {
+            return capacity_;
+        }
+        BufferCategory category() const noexcept
+        {
+            return category_;
+        }
+        bool empty() const noexcept
+        {
+            return data_ == nullptr;
+        }
+        explicit operator bool() const noexcept
+        {
+            return !empty();
+        }
+
+        void reset() noexcept;
+
+      private:
+        friend class IBufferProvider;
+
+        BufferLease(
+            std::weak_ptr<IBufferProvider> owner,
+            BufferCategory category,
+            std::size_t slotIndex,
+            char* data,
+            std::size_t size,
+            std::size_t capacity
+        ) noexcept;
+
+        std::weak_ptr<IBufferProvider> owner_{};
+        BufferCategory category_{BufferCategory::Tiny};
+        std::size_t slotIndex_{0};
+        char* data_{nullptr};
+        std::size_t size_{0};
+        std::size_t capacity_{0};
+    };
+
+    /**
+     * @brief Type-erased interface so callers do not see the BufferProvider's template parameters.
+     */
+    class IBufferProvider : public std::enable_shared_from_this<IBufferProvider>
+    {
+      public:
+        virtual ~IBufferProvider() = default;
+
+        /**
+         * @brief Lease a buffer sized for the caller's working set.
+         * @param sizeHint Expected working size (e.g. file size).
+         * @return An empty lease if the chosen category and its one-smaller fallback are both exhausted.
+         */
+        virtual BufferLease lease(std::size_t sizeHint) = 0;
+
+        /**
+         * @brief Lease a buffer and additionally clamp the reported usable size by a server-negotiated limit.
+         *        The underlying slot still has its full category capacity.
+         */
+        virtual BufferLease leaseForTransfer(std::size_t sizeHint, std::size_t serverLimit) = 0;
+
+      protected:
+        friend class BufferLease;
+
+        virtual void release(BufferCategory category, std::size_t slotIndex) noexcept = 0;
+
+        /**
+         * @brief Helper for derived classes to construct leases.
+         */
+        BufferLease makeLease(
+            BufferCategory category,
+            std::size_t slotIndex,
+            char* data,
+            std::size_t size,
+            std::size_t capacity
+        );
+    };
+
+    namespace Detail
+    {
+        template <typename... Slots>
+        constexpr bool allCategoriesPresentOnce() noexcept
+        {
+            constexpr std::array<BufferCategory, 5> required{
+                BufferCategory::Tiny,
+                BufferCategory::Small,
+                BufferCategory::Medium,
+                BufferCategory::Large,
+                BufferCategory::Max,
+            };
+            constexpr std::array<BufferCategory, sizeof...(Slots)> provided{Slots::category...};
+
+            for (auto req : required)
+            {
+                std::size_t count = 0;
+                for (auto prov : provided)
+                {
+                    if (prov == req)
+                        ++count;
+                }
+                if (count != 1)
+                    return false;
+            }
+            return true;
+        }
+
+        template <BufferCategory Category, typename... Slots>
+        constexpr std::size_t findBucketIndex() noexcept
+        {
+            constexpr std::array<BufferCategory, sizeof...(Slots)> cats{Slots::category...};
+            for (std::size_t index = 0; index < cats.size(); ++index)
+            {
+                if (cats[index] == Category)
+                    return index;
+            }
+            return static_cast<std::size_t>(-1);
+        }
+
+        constexpr BufferCategory oneCategorySmaller(BufferCategory category) noexcept
+        {
+            switch (category)
+            {
+                case BufferCategory::Max:
+                    return BufferCategory::Large;
+                case BufferCategory::Large:
+                    return BufferCategory::Medium;
+                case BufferCategory::Medium:
+                    return BufferCategory::Small;
+                case BufferCategory::Small:
+                    return BufferCategory::Tiny;
+                case BufferCategory::Tiny:
+                    return BufferCategory::Tiny;
+            }
+            return BufferCategory::Tiny;
+        }
+    }
+
+    /**
+     * @brief Pre-allocated, fixed-capacity buffer pool with compile-time bucket configuration.
+     *
+     * @tparam MaxCategoryThresholdBytes Files strictly smaller than this are not eligible for the Max bucket.
+     * @tparam Slots One CategorySlots<> per BufferCategory value; all five categories must be present exactly once.
+     */
+    template <std::size_t MaxCategoryThresholdBytes, typename... Slots>
+    class BufferProvider final : public IBufferProvider
+    {
+        static_assert(sizeof...(Slots) == 5u, "BufferProvider must be configured with exactly 5 CategorySlots");
+        static_assert(
+            Detail::allCategoriesPresentOnce<Slots...>(),
+            "BufferProvider must include each BufferCategory exactly once"
+        );
+
+      public:
+        /**
+         * @brief Factory — BufferProvider requires shared-ownership (enable_shared_from_this).
+         */
+        static std::shared_ptr<BufferProvider> create()
+        {
+            return std::shared_ptr<BufferProvider>{new BufferProvider{}};
+        }
+
+        static constexpr std::size_t maxCategoryThresholdBytes = MaxCategoryThresholdBytes;
+
+        BufferLease lease(std::size_t sizeHint) override
+        {
+            const auto category = pickCategory(sizeHint);
+            const auto reported = bufferCategorySize(category);
+            return tryLeaseWithFallback(category, reported);
+        }
+
+        BufferLease leaseForTransfer(std::size_t sizeHint, std::size_t serverLimit) override
+        {
+            const auto category = pickCategory(sizeHint);
+            const auto reported = std::min(bufferCategorySize(category), serverLimit);
+            return tryLeaseWithFallback(category, reported);
+        }
+
+      private:
+        BufferProvider() = default;
+
+        template <BufferCategory Category>
+        auto& bucket() noexcept
+        {
+            constexpr auto index = Detail::findBucketIndex<Category, Slots...>();
+            return std::get<index>(buckets_);
+        }
+
+        BufferCategory pickCategory(std::size_t sizeHint) const noexcept
+        {
+            const BufferCategory cap = (sizeHint >= MaxCategoryThresholdBytes) ? BufferCategory::Max
+                                                                               : BufferCategory::Large;
+
+            constexpr std::array<BufferCategory, 5> ordered{
+                BufferCategory::Tiny,
+                BufferCategory::Small,
+                BufferCategory::Medium,
+                BufferCategory::Large,
+                BufferCategory::Max,
+            };
+
+            for (auto candidate : ordered)
+            {
+                if (static_cast<int>(candidate) > static_cast<int>(cap))
+                    break;
+                if (bufferCategorySize(candidate) >= sizeHint)
+                    return candidate;
+            }
+            return cap;
+        }
+
+        BufferLease tryLeaseWithFallback(BufferCategory requested, std::size_t reportedSize)
+        {
+            BufferLease lease = tryLeaseCategory(requested, reportedSize);
+            if (lease)
+                return lease;
+
+            if (requested == BufferCategory::Tiny)
+                return lease;
+
+            const auto fallback = Detail::oneCategorySmaller(requested);
+            const auto fallbackReported = std::min(reportedSize, bufferCategorySize(fallback));
+            return tryLeaseCategory(fallback, fallbackReported);
+        }
+
+        BufferLease tryLeaseCategory(BufferCategory category, std::size_t reportedSize)
+        {
+            switch (category)
+            {
+                case BufferCategory::Tiny:
+                    return tryLeaseImpl<BufferCategory::Tiny>(reportedSize);
+                case BufferCategory::Small:
+                    return tryLeaseImpl<BufferCategory::Small>(reportedSize);
+                case BufferCategory::Medium:
+                    return tryLeaseImpl<BufferCategory::Medium>(reportedSize);
+                case BufferCategory::Large:
+                    return tryLeaseImpl<BufferCategory::Large>(reportedSize);
+                case BufferCategory::Max:
+                    return tryLeaseImpl<BufferCategory::Max>(reportedSize);
+            }
+            return {};
+        }
+
+        template <BufferCategory Category>
+        BufferLease tryLeaseImpl(std::size_t reportedSize)
+        {
+            std::lock_guard lock{mutex_};
+            auto& b = bucket<Category>();
+            for (std::size_t index = 0; index < b.taken.size(); ++index)
+            {
+                if (!b.taken[index])
+                {
+                    b.taken[index] = true;
+                    char* const data = b.slots[index].data();
+                    return makeLease(Category, index, data, reportedSize, bufferCategorySize(Category));
+                }
+            }
+            return {};
+        }
+
+        void release(BufferCategory category, std::size_t slotIndex) noexcept override
+        {
+            std::lock_guard lock{mutex_};
+            switch (category)
+            {
+                case BufferCategory::Tiny:
+                    bucket<BufferCategory::Tiny>().taken[slotIndex] = false;
+                    return;
+                case BufferCategory::Small:
+                    bucket<BufferCategory::Small>().taken[slotIndex] = false;
+                    return;
+                case BufferCategory::Medium:
+                    bucket<BufferCategory::Medium>().taken[slotIndex] = false;
+                    return;
+                case BufferCategory::Large:
+                    bucket<BufferCategory::Large>().taken[slotIndex] = false;
+                    return;
+                case BufferCategory::Max:
+                    bucket<BufferCategory::Max>().taken[slotIndex] = false;
+                    return;
+            }
+        }
+
+        std::tuple<TypedBucket<Slots::category, Slots::count>...> buckets_{};
+        mutable std::mutex mutex_{};
+    };
+
+    /**
+     * @brief Default pool: 8/8/8 small-to-medium slots, 4/4 large slots, Max gated at 1 MiB.
+     */
+    using DefaultBufferProvider = BufferProvider<
+        1ull * 1024ull * 1024ull,
+        CategorySlots<BufferCategory::Tiny, 8>,
+        CategorySlots<BufferCategory::Small, 8>,
+        CategorySlots<BufferCategory::Medium, 8>,
+        CategorySlots<BufferCategory::Large, 4>,
+        CategorySlots<BufferCategory::Max, 4>>;
+}

--- a/ssh/include/ssh/async/transfer_context.hpp
+++ b/ssh/include/ssh/async/transfer_context.hpp
@@ -25,6 +25,14 @@ namespace SecureShell
         bool hasEnded() const;
         void calculateBytesPerSecond();
 
+        /**
+         * @brief Add to the running bytes-transferred counter from outside the
+         *        async FileStream path (e.g. a sync read-loop driven by an
+         *        Operation that still wants the throughput-meter machinery).
+         *        Pair with periodic calls to @ref calculateBytesPerSecond.
+         */
+        void addBytesTransferred(SignedSizeType delta);
+
       private:
         std::atomic_bool ended_{false};
         std::atomic_bool paused_{false};

--- a/ssh/include/ssh/session.hpp
+++ b/ssh/include/ssh/session.hpp
@@ -45,19 +45,6 @@ namespace SecureShell
          */
         void start();
 
-        /**
-         * @brief Stops processing but does not close the session and channels.
-         */
-        void stop();
-
-        /**
-         * @brief Returns true if the session is running and processing channels.
-         *
-         * @return true
-         * @return false
-         */
-        bool isRunning() const;
-
         struct PtyCreationOptions
         {
             std::optional<std::map<std::string, std::string>> environment = std::nullopt;

--- a/ssh/include/ssh/sftp_error.hpp
+++ b/ssh/include/ssh/sftp_error.hpp
@@ -16,6 +16,7 @@ namespace SecureShell
         ShortWrite,
         FileNull,
         TaskPushFailed,
+        BufferUnavailable,
     };
 
     struct SftpError

--- a/ssh/include/ssh/sftp_session.hpp
+++ b/ssh/include/ssh/sftp_session.hpp
@@ -2,6 +2,7 @@
 
 #include <libssh/libsshpp.hpp>
 #include <libssh/sftp.h>
+#include <ssh/async/buffer_provider.hpp>
 #include <ssh/async/processing_thread.hpp>
 #include <ssh/async/processing_strand.hpp>
 #include <ssh/file_information.hpp>
@@ -293,6 +294,14 @@ namespace SecureShell
             return strand_.get();
         }
 
+        /**
+         * @brief Shared buffer pool for this session's file transfers.
+         */
+        IBufferProvider& bufferProvider() noexcept
+        {
+            return *bufferProvider_;
+        }
+
         struct DeepLinkResult
         {
             std::filesystem::path linkTarget;
@@ -325,6 +334,7 @@ namespace SecureShell
         Session* owner_;
         std::unique_ptr<ProcessingStrand> strand_;
         sftp_session session_;
+        std::shared_ptr<IBufferProvider> bufferProvider_;
         std::vector<std::shared_ptr<FileStream>> fileStreams_;
     };
 

--- a/ssh/source/ssh/CMakeLists.txt
+++ b/ssh/source/ssh/CMakeLists.txt
@@ -1,6 +1,7 @@
 add_library(
     secure-shell
     STATIC
+        async/buffer_provider.cpp
         async/processing_thread.cpp
         async/transfer_context.cpp
         session.cpp

--- a/ssh/source/ssh/async/buffer_provider.cpp
+++ b/ssh/source/ssh/async/buffer_provider.cpp
@@ -1,0 +1,80 @@
+#include <ssh/async/buffer_provider.hpp>
+
+#include <utility>
+
+namespace SecureShell
+{
+    BufferLease::BufferLease(
+        std::weak_ptr<IBufferProvider> owner,
+        BufferCategory category,
+        std::size_t slotIndex,
+        char* data,
+        std::size_t size,
+        std::size_t capacity
+    ) noexcept
+        : owner_{std::move(owner)}
+        , category_{category}
+        , slotIndex_{slotIndex}
+        , data_{data}
+        , size_{size}
+        , capacity_{capacity}
+    {}
+
+    BufferLease::BufferLease(BufferLease&& other) noexcept
+        : owner_{std::move(other.owner_)}
+        , category_{other.category_}
+        , slotIndex_{other.slotIndex_}
+        , data_{other.data_}
+        , size_{other.size_}
+        , capacity_{other.capacity_}
+    {
+        other.data_ = nullptr;
+        other.size_ = 0;
+        other.capacity_ = 0;
+    }
+
+    BufferLease& BufferLease::operator=(BufferLease&& other) noexcept
+    {
+        if (this != &other)
+        {
+            reset();
+            owner_ = std::move(other.owner_);
+            category_ = other.category_;
+            slotIndex_ = other.slotIndex_;
+            data_ = other.data_;
+            size_ = other.size_;
+            capacity_ = other.capacity_;
+            other.data_ = nullptr;
+            other.size_ = 0;
+            other.capacity_ = 0;
+        }
+        return *this;
+    }
+
+    BufferLease::~BufferLease()
+    {
+        reset();
+    }
+
+    void BufferLease::reset() noexcept
+    {
+        if (data_ == nullptr)
+            return;
+        if (auto provider = owner_.lock())
+            provider->release(category_, slotIndex_);
+        data_ = nullptr;
+        size_ = 0;
+        capacity_ = 0;
+    }
+
+    BufferLease IBufferProvider::makeLease(
+        BufferCategory category,
+        std::size_t slotIndex,
+        char* data,
+        std::size_t size,
+        std::size_t capacity
+    )
+    {
+        return BufferLease{weak_from_this(), category, slotIndex, data, size, capacity};
+    }
+}

--- a/ssh/source/ssh/async/transfer_context.cpp
+++ b/ssh/source/ssh/async/transfer_context.cpp
@@ -32,6 +32,11 @@ namespace SecureShell
         paused_.store(doPause);
     }
 
+    void AsyncTransferContext::addBytesTransferred(SignedSizeType delta)
+    {
+        bytesTransferred_ += delta;
+    }
+
     void AsyncTransferContext::calculateBytesPerSecond()
     {
         using namespace std::chrono_literals;

--- a/ssh/source/ssh/file_stream.cpp
+++ b/ssh/source/ssh/file_stream.cpp
@@ -190,14 +190,14 @@ namespace SecureShell
         struct ReadState : public std::enable_shared_from_this<ReadState>
         {
             FileStream& stream;
-            std::string buffer;
+            BufferLease buffer;
             std::function<bool(std::string_view data)> callback;
             std::promise<std::expected<std::size_t, SftpError>> promise;
             std::size_t totalRead;
 
-            ReadState(FileStream& stream, std::size_t limit, std::function<bool(std::string_view data)> callback)
+            ReadState(FileStream& stream, BufferLease buffer, std::function<bool(std::string_view data)> callback)
                 : stream{stream}
-                , buffer(std::min(std::size_t{4096}, limit), '\0')
+                , buffer{std::move(buffer)}
                 , callback{std::move(callback)}
                 , promise{}
                 , totalRead{0}
@@ -253,7 +253,37 @@ namespace SecureShell
             }
         };
 
-        auto state = std::make_shared<ReadState>(*this, readLengthLimit(), std::move(onReadFunc));
+        auto sftp = sftp_.lock();
+        if (!sftp)
+        {
+            std::promise<std::expected<std::size_t, SftpError>> promise{};
+            promise.set_value(
+                std::unexpected(
+                    SftpError{
+                        .message = "Owner is null",
+                        .wrapperError = WrapperErrors::OwnerNull,
+                    }
+                )
+            );
+            return promise.get_future();
+        }
+
+        auto lease = sftp->bufferProvider().leaseForTransfer(readLengthLimit(), readLengthLimit());
+        if (lease.empty())
+        {
+            std::promise<std::expected<std::size_t, SftpError>> promise{};
+            promise.set_value(
+                std::unexpected(
+                    SftpError{
+                        .message = "No buffer available from pool",
+                        .wrapperError = WrapperErrors::BufferUnavailable,
+                    }
+                )
+            );
+            return promise.get_future();
+        }
+
+        auto state = std::make_shared<ReadState>(*this, std::move(lease), std::move(onReadFunc));
         state->doRead();
         return state->promise.get_future();
     }

--- a/ssh/source/ssh/session.cpp
+++ b/ssh/source/ssh/session.cpp
@@ -102,16 +102,6 @@ namespace SecureShell
         );
     }
 
-    void Session::stop()
-    {
-        processingThread_.stop();
-    }
-
-    bool Session::isRunning() const
-    {
-        return processingThread_.isRunning();
-    }
-
     void Session::shutdown()
     {
         removeAllChannels();

--- a/ssh/source/ssh/sftp_session.cpp
+++ b/ssh/source/ssh/sftp_session.cpp
@@ -12,6 +12,7 @@ namespace SecureShell
         : owner_{owner}
         , strand_{std::move(strand)}
         , session_{session}
+        , bufferProvider_{DefaultBufferProvider::create()}
         , fileStreams_{}
     {}
     SftpSession::~SftpSession()

--- a/ssh/test/ssh/main.cpp
+++ b/ssh/test/ssh/main.cpp
@@ -1,3 +1,4 @@
+#include "test_buffer_provider.hpp"
 #include "test_processing_thread.hpp"
 #include "test_ssh_session.hpp"
 #include "test_sftp.hpp"

--- a/ssh/test/ssh/test_buffer_provider.hpp
+++ b/ssh/test/ssh/test_buffer_provider.hpp
@@ -1,0 +1,265 @@
+#pragma once
+
+#include <ssh/async/buffer_provider.hpp>
+
+#include <gtest/gtest.h>
+
+#include <array>
+#include <atomic>
+#include <thread>
+#include <vector>
+
+namespace SecureShell::Test
+{
+    class BufferProviderTests : public ::testing::Test
+    {
+      public:
+        using Provider = DefaultBufferProvider;
+        /** Threshold gating the Max bucket (same as DefaultBufferProvider). */
+        static constexpr std::size_t kMaxThreshold = 1ull * 1024ull * 1024ull;
+    };
+
+    TEST_F(BufferProviderTests, LeaseHintZeroPicksTiny)
+    {
+        auto provider = Provider::create();
+        auto lease = provider->lease(0);
+        ASSERT_TRUE(lease);
+        EXPECT_EQ(lease.category(), BufferCategory::Tiny);
+        EXPECT_EQ(lease.size(), bufferCategorySize(BufferCategory::Tiny));
+    }
+
+    TEST_F(BufferProviderTests, LeaseHintSmallerThanTinyFitsTiny)
+    {
+        auto provider = Provider::create();
+        auto lease = provider->lease(512);
+        ASSERT_TRUE(lease);
+        EXPECT_EQ(lease.category(), BufferCategory::Tiny);
+    }
+
+    TEST_F(BufferProviderTests, LeaseHintBetweenTinyAndSmallPicksSmall)
+    {
+        auto provider = Provider::create();
+        auto lease = provider->lease(bufferCategorySize(BufferCategory::Tiny) + 1);
+        ASSERT_TRUE(lease);
+        EXPECT_EQ(lease.category(), BufferCategory::Small);
+    }
+
+    TEST_F(BufferProviderTests, LeaseHintBetweenSmallAndMediumPicksMedium)
+    {
+        auto provider = Provider::create();
+        auto lease = provider->lease(bufferCategorySize(BufferCategory::Small) + 1);
+        ASSERT_TRUE(lease);
+        EXPECT_EQ(lease.category(), BufferCategory::Medium);
+    }
+
+    TEST_F(BufferProviderTests, LeaseHintBetweenMediumAndLargePicksLarge)
+    {
+        auto provider = Provider::create();
+        auto lease = provider->lease(bufferCategorySize(BufferCategory::Medium) + 1);
+        ASSERT_TRUE(lease);
+        EXPECT_EQ(lease.category(), BufferCategory::Large);
+    }
+
+    TEST_F(BufferProviderTests, LeaseBelowThresholdCapsAtLargeEvenWhenHintExceedsLarge)
+    {
+        auto provider = Provider::create();
+        // Hint exceeds Large (64 KiB) but is still well under the 1 MiB threshold gating Max.
+        auto lease = provider->lease(bufferCategorySize(BufferCategory::Large) + 1);
+        ASSERT_TRUE(lease);
+        EXPECT_EQ(lease.category(), BufferCategory::Large);
+    }
+
+    TEST_F(BufferProviderTests, LeaseAtOrAboveThresholdPicksMax)
+    {
+        auto provider = Provider::create();
+        auto lease = provider->lease(kMaxThreshold);
+        ASSERT_TRUE(lease);
+        EXPECT_EQ(lease.category(), BufferCategory::Max);
+        EXPECT_EQ(lease.size(), bufferCategorySize(BufferCategory::Max));
+    }
+
+    TEST_F(BufferProviderTests, LeaseForTransferClampsSizeByServerLimit)
+    {
+        auto provider = Provider::create();
+        const std::size_t serverLimit = 2 * 1024;
+        auto lease = provider->leaseForTransfer(bufferCategorySize(BufferCategory::Large), serverLimit);
+        ASSERT_TRUE(lease);
+        EXPECT_EQ(lease.size(), serverLimit);
+        EXPECT_GE(lease.capacity(), serverLimit);
+    }
+
+    TEST_F(BufferProviderTests, LeaseReusesReleasedSlot)
+    {
+        auto provider = Provider::create();
+        char* firstPointer = nullptr;
+        {
+            auto lease = provider->lease(bufferCategorySize(BufferCategory::Small));
+            ASSERT_TRUE(lease);
+            firstPointer = lease.data();
+        }
+        auto second = provider->lease(bufferCategorySize(BufferCategory::Small));
+        ASSERT_TRUE(second);
+        EXPECT_EQ(second.data(), firstPointer);
+    }
+
+    TEST_F(BufferProviderTests, ExhaustingBucketFallsBackOneSmaller)
+    {
+        auto provider = Provider::create();
+        std::vector<BufferLease> medium{};
+        for (std::size_t i = 0; i < 8; ++i)
+        {
+            auto lease = provider->lease(bufferCategorySize(BufferCategory::Medium));
+            ASSERT_TRUE(lease) << "Medium slot " << i;
+            ASSERT_EQ(lease.category(), BufferCategory::Medium);
+            medium.push_back(std::move(lease));
+        }
+
+        auto fallback = provider->lease(bufferCategorySize(BufferCategory::Medium));
+        ASSERT_TRUE(fallback);
+        EXPECT_EQ(fallback.category(), BufferCategory::Small);
+        EXPECT_EQ(fallback.size(), bufferCategorySize(BufferCategory::Small));
+    }
+
+    TEST_F(BufferProviderTests, FallbackBottomsOutAtEmpty)
+    {
+        auto provider = Provider::create();
+        std::vector<BufferLease> tinies{};
+        for (std::size_t i = 0; i < 8; ++i)
+        {
+            auto lease = provider->lease(0);
+            ASSERT_TRUE(lease);
+            tinies.push_back(std::move(lease));
+        }
+        std::vector<BufferLease> smalls{};
+        for (std::size_t i = 0; i < 8; ++i)
+        {
+            auto lease = provider->lease(bufferCategorySize(BufferCategory::Small));
+            ASSERT_TRUE(lease);
+            ASSERT_EQ(lease.category(), BufferCategory::Small);
+            smalls.push_back(std::move(lease));
+        }
+
+        auto empty = provider->lease(bufferCategorySize(BufferCategory::Small));
+        EXPECT_FALSE(empty);
+        EXPECT_TRUE(empty.empty());
+        EXPECT_EQ(empty.data(), nullptr);
+    }
+
+    TEST_F(BufferProviderTests, RecoveryAfterRelease)
+    {
+        auto provider = Provider::create();
+        std::vector<BufferLease> held{};
+        for (std::size_t i = 0; i < 8; ++i)
+            held.push_back(provider->lease(bufferCategorySize(BufferCategory::Medium)));
+
+        // Exhausted: next ask falls back to Small.
+        auto fallback = provider->lease(bufferCategorySize(BufferCategory::Medium));
+        EXPECT_EQ(fallback.category(), BufferCategory::Small);
+
+        // Free one Medium, next same-category ask succeeds in Medium again.
+        held.pop_back();
+        auto recovered = provider->lease(bufferCategorySize(BufferCategory::Medium));
+        ASSERT_TRUE(recovered);
+        EXPECT_EQ(recovered.category(), BufferCategory::Medium);
+    }
+
+    TEST_F(BufferProviderTests, ProviderOutlivesLeaseSafely)
+    {
+        auto provider = Provider::create();
+        auto lease = provider->lease(bufferCategorySize(BufferCategory::Tiny));
+        ASSERT_TRUE(lease);
+        provider.reset();
+        // Lease destructor now runs with a dead provider — weak_ptr guard must prevent dangling.
+        (void)lease;
+    }
+
+    TEST_F(BufferProviderTests, MoveConstructorTransfersOwnership)
+    {
+        auto provider = Provider::create();
+        auto original = provider->lease(bufferCategorySize(BufferCategory::Tiny));
+        ASSERT_TRUE(original);
+        char* ptr = original.data();
+
+        BufferLease moved{std::move(original)};
+        EXPECT_TRUE(moved);
+        EXPECT_EQ(moved.data(), ptr);
+        EXPECT_FALSE(original);
+        EXPECT_EQ(original.data(), nullptr);
+    }
+
+    TEST_F(BufferProviderTests, MoveAssignmentReturnsPreviousSlot)
+    {
+        auto provider = Provider::create();
+        auto first = provider->lease(bufferCategorySize(BufferCategory::Tiny));
+        char* firstPtr = first.data();
+
+        auto second = provider->lease(bufferCategorySize(BufferCategory::Tiny));
+        char* secondPtr = second.data();
+        ASSERT_NE(firstPtr, secondPtr);
+
+        first = std::move(second);
+        EXPECT_EQ(first.data(), secondPtr);
+
+        // The slot formerly held by `first` is now back in the pool. Leasing again must hand it out.
+        auto rebind = provider->lease(bufferCategorySize(BufferCategory::Tiny));
+        EXPECT_EQ(rebind.data(), firstPtr);
+    }
+
+    TEST_F(BufferProviderTests, ResetReleasesEagerly)
+    {
+        auto provider = Provider::create();
+        auto lease = provider->lease(bufferCategorySize(BufferCategory::Tiny));
+        ASSERT_TRUE(lease);
+        char* ptr = lease.data();
+
+        lease.reset();
+        EXPECT_FALSE(lease);
+
+        auto again = provider->lease(bufferCategorySize(BufferCategory::Tiny));
+        EXPECT_EQ(again.data(), ptr);
+    }
+
+    TEST_F(BufferProviderTests, TinyAndSmallAreInlineInProviderObject)
+    {
+        // Sanity check that the Tiny and Small buckets occupy real storage inside the provider
+        // object (not heap-indirected via std::vector). Total inline bytes must be at least
+        // (TinySize * TinyCount) + (SmallSize * SmallCount) = 8 KiB + 32 KiB = 40 KiB.
+        constexpr std::size_t expectedInline = (bufferCategorySize(BufferCategory::Tiny) * 8u) +
+            (bufferCategorySize(BufferCategory::Small) * 8u);
+        EXPECT_GE(sizeof(Provider), expectedInline);
+    }
+
+    TEST_F(BufferProviderTests, ConcurrentLeaseReleaseIsSafe)
+    {
+        auto provider = Provider::create();
+        constexpr int threadsCount = 8;
+        constexpr int iterationsPerThread = 200;
+
+        std::atomic<int> failures{0};
+        std::vector<std::thread> workers{};
+        workers.reserve(threadsCount);
+        for (int threadIndex = 0; threadIndex < threadsCount; ++threadIndex)
+        {
+            workers.emplace_back(
+                [&provider, &failures]()
+                {
+                    for (int i = 0; i < iterationsPerThread; ++i)
+                    {
+                        auto lease = provider->lease(bufferCategorySize(BufferCategory::Small));
+                        if (!lease)
+                        {
+                            ++failures;
+                            continue;
+                        }
+                        // Touch the buffer to catch obvious corruption.
+                        lease.data()[0] = static_cast<char>(i & 0x7f);
+                    }
+                }
+            );
+        }
+        for (auto& w : workers)
+            w.join();
+
+        EXPECT_EQ(failures.load(), 0);
+    }
+}

--- a/ssh/test/ssh/test_sftp.hpp
+++ b/ssh/test/ssh/test_sftp.hpp
@@ -4,8 +4,13 @@
 #include <ssh/session.hpp>
 #include <nui/utility/scope_exit.hpp>
 #include <ssh/sftp_session.hpp>
+#include <ssh/file_stream.hpp>
+#include <ssh/async/transfer_context.hpp>
 
 #include <gtest/gtest.h>
+
+#include <array>
+#include <atomic>
 
 using namespace std::chrono_literals;
 using namespace std::string_literals;
@@ -355,7 +360,7 @@ namespace SecureShell::Test
         auto readResult = readFut.get();
         ASSERT_TRUE(readResult.has_value());
 
-        EXPECT_EQ(data, createAlphabetString(1024 * 1024));
+        EXPECT_EQ(data, createAlphabetString(65536));
     }
 
     TEST_F(SftpTests, CanMoveReadCursorForward)
@@ -491,5 +496,188 @@ namespace SecureShell::Test
         ASSERT_TRUE(statResult.has_value());
 
         EXPECT_GT(statResult.value().size, 0);
+    }
+
+    TEST_F(SftpTests, CanReadFileAsync)
+    {
+        CREATE_SERVER_AND_JOINER(Sftp);
+        auto [_, sftp] = createSftpSession(serverStartResult->port);
+
+        auto fut =
+            sftp->openFile("/home/test/large.txt", SftpSession::OpenType::Read, std::filesystem::perms::owner_read);
+        ASSERT_EQ(fut.wait_for(1s), std::future_status::ready);
+        auto result = fut.get();
+        ASSERT_TRUE(result.has_value());
+        auto file = std::move(result).value().lock();
+        ASSERT_TRUE(file);
+
+        constexpr std::size_t totalSize = 65536;
+        using SignedSize = SecureShell::IFileStream::SignedSizeType;
+
+        std::array<char, 4096> buffer{};
+        std::string data;
+        data.reserve(totalSize);
+
+        auto ctxFut = file->readAsync(
+            static_cast<SignedSize>(totalSize),
+            buffer.data(),
+            static_cast<SignedSize>(buffer.size()),
+            [&data, &buffer](SignedSize bytesRead)
+            {
+                data.append(buffer.data(), static_cast<std::size_t>(bytesRead));
+                return true;
+            }
+        );
+        ASSERT_EQ(ctxFut.wait_for(1s), std::future_status::ready);
+        auto ctxResult = ctxFut.get();
+        ASSERT_TRUE(ctxResult.has_value());
+        auto ctx = std::move(ctxResult).value();
+
+        const auto deadline = std::chrono::steady_clock::now() + 5s;
+        while (!ctx->hasEnded() && std::chrono::steady_clock::now() < deadline)
+            std::this_thread::sleep_for(10ms);
+
+        EXPECT_TRUE(ctx->hasEnded());
+        EXPECT_EQ(ctx->bytesTransferred(), static_cast<SignedSize>(totalSize));
+        EXPECT_EQ(data, createAlphabetString(totalSize));
+    }
+
+    TEST_F(SftpTests, AsyncReadCanBePaused)
+    {
+        CREATE_SERVER_AND_JOINER(Sftp);
+        auto [_, sftp] = createSftpSession(serverStartResult->port);
+
+        auto fut =
+            sftp->openFile("/home/test/large.txt", SftpSession::OpenType::Read, std::filesystem::perms::owner_read);
+        ASSERT_EQ(fut.wait_for(1s), std::future_status::ready);
+        auto result = fut.get();
+        ASSERT_TRUE(result.has_value());
+        auto file = std::move(result).value().lock();
+        ASSERT_TRUE(file);
+
+        constexpr std::size_t totalSize = 65536;
+        using SignedSize = SecureShell::IFileStream::SignedSizeType;
+
+        std::array<char, 1024> buffer{};
+        std::atomic<SignedSize> readCount{0};
+
+        auto ctxFut = file->readAsync(
+            static_cast<SignedSize>(totalSize),
+            buffer.data(),
+            static_cast<SignedSize>(buffer.size()),
+            [&readCount](SignedSize bytesRead)
+            {
+                readCount += bytesRead;
+                return true;
+            }
+        );
+        ASSERT_EQ(ctxFut.wait_for(1s), std::future_status::ready);
+        auto ctxResult = ctxFut.get();
+        ASSERT_TRUE(ctxResult.has_value());
+        auto ctx = std::move(ctxResult).value();
+
+        ctx->pause(true);
+        std::this_thread::sleep_for(200ms);
+        const auto snapshot = ctx->bytesTransferred();
+        std::this_thread::sleep_for(200ms);
+        EXPECT_EQ(ctx->bytesTransferred(), snapshot);
+        EXPECT_FALSE(ctx->hasEnded());
+
+        ctx->pause(false);
+
+        const auto deadline = std::chrono::steady_clock::now() + 5s;
+        while (!ctx->hasEnded() && std::chrono::steady_clock::now() < deadline)
+            std::this_thread::sleep_for(10ms);
+
+        EXPECT_TRUE(ctx->hasEnded());
+        EXPECT_EQ(ctx->bytesTransferred(), static_cast<SignedSize>(totalSize));
+    }
+
+    TEST_F(SftpTests, AsyncReadCanBeCancelled)
+    {
+        CREATE_SERVER_AND_JOINER(Sftp);
+        auto [_, sftp] = createSftpSession(serverStartResult->port);
+
+        auto fut =
+            sftp->openFile("/home/test/large.txt", SftpSession::OpenType::Read, std::filesystem::perms::owner_read);
+        ASSERT_EQ(fut.wait_for(1s), std::future_status::ready);
+        auto result = fut.get();
+        ASSERT_TRUE(result.has_value());
+        auto file = std::move(result).value().lock();
+        ASSERT_TRUE(file);
+
+        constexpr std::size_t totalSize = 65536;
+        using SignedSize = SecureShell::IFileStream::SignedSizeType;
+
+        std::array<char, 1024> buffer{};
+        std::atomic<SignedSize> readCount{0};
+
+        auto ctxFut = file->readAsync(
+            static_cast<SignedSize>(totalSize),
+            buffer.data(),
+            static_cast<SignedSize>(buffer.size()),
+            [&readCount](SignedSize bytesRead)
+            {
+                readCount += bytesRead;
+                return true;
+            }
+        );
+        ASSERT_EQ(ctxFut.wait_for(1s), std::future_status::ready);
+        auto ctxResult = ctxFut.get();
+        ASSERT_TRUE(ctxResult.has_value());
+        auto ctx = std::move(ctxResult).value();
+
+        ctx->pause(true);
+        ctx->cancel();
+
+        EXPECT_TRUE(ctx->hasEnded());
+
+        std::this_thread::sleep_for(200ms);
+        const auto afterCancel = ctx->bytesTransferred();
+        std::this_thread::sleep_for(200ms);
+        EXPECT_EQ(ctx->bytesTransferred(), afterCancel);
+        EXPECT_LT(ctx->bytesTransferred(), static_cast<SignedSize>(totalSize));
+    }
+
+    TEST_F(SftpTests, AsyncReadStopsWhenCallbackReturnsFalse)
+    {
+        CREATE_SERVER_AND_JOINER(Sftp);
+        auto [_, sftp] = createSftpSession(serverStartResult->port);
+
+        auto fut =
+            sftp->openFile("/home/test/large.txt", SftpSession::OpenType::Read, std::filesystem::perms::owner_read);
+        ASSERT_EQ(fut.wait_for(1s), std::future_status::ready);
+        auto result = fut.get();
+        ASSERT_TRUE(result.has_value());
+        auto file = std::move(result).value().lock();
+        ASSERT_TRUE(file);
+
+        constexpr std::size_t totalSize = 65536;
+        using SignedSize = SecureShell::IFileStream::SignedSizeType;
+
+        std::array<char, 1024> buffer{};
+        std::atomic<int> callCount{0};
+
+        auto ctxFut = file->readAsync(
+            static_cast<SignedSize>(totalSize),
+            buffer.data(),
+            static_cast<SignedSize>(buffer.size()),
+            [&callCount](SignedSize)
+            {
+                return ++callCount < 3;
+            }
+        );
+        ASSERT_EQ(ctxFut.wait_for(1s), std::future_status::ready);
+        auto ctxResult = ctxFut.get();
+        ASSERT_TRUE(ctxResult.has_value());
+        auto ctx = std::move(ctxResult).value();
+
+        const auto deadline = std::chrono::steady_clock::now() + 2s;
+        while (!ctx->hasEnded() && std::chrono::steady_clock::now() < deadline)
+            std::this_thread::sleep_for(10ms);
+
+        EXPECT_TRUE(ctx->hasEnded());
+        EXPECT_EQ(callCount.load(), 3);
+        EXPECT_LT(ctx->bytesTransferred(), static_cast<SignedSize>(totalSize));
     }
 }

--- a/ssh/test/ssh/test_ssh2_servers/sftp_server.mjs
+++ b/ssh/test/ssh/test_ssh2_servers/sftp_server.mjs
@@ -89,9 +89,9 @@ const fakeFilesystem = finalizeFakeFs({
                 file('file1.txt', 'Fake file content'),
                 file('file2.txt', 'Fake file content'),
                 file('large.txt', (() => {
-                    const size = 1024 * 1024;
+                    const size = 65536;
                     const repeatable = 'abcdefghijklmnopqrstuvwxyz';
-                    const division = size / repeatable.length;
+                    const division = Math.floor(size / repeatable.length);
                     const mod = size % repeatable.length;
                     return repeatable.repeat(division) + repeatable.slice(0, mod);
                 })())

--- a/ssh/test/ssh/test_ssh_session.hpp
+++ b/ssh/test/ssh/test_ssh_session.hpp
@@ -36,27 +36,6 @@ namespace SecureShell::Test
         SecureShell::Session client{[]() {}};
     }
 
-    TEST_F(SshSessionTests, CanStartAndStopSession)
-    {
-        auto [result, processThread] = createSshServer();
-        ASSERT_TRUE(result);
-        auto joiner = Nui::ScopeExit{[&]() noexcept
-            {
-                result->command("exit");
-                if (processThread.joinable())
-                    processThread.join();
-            }};
-
-        auto expectedSession = makePasswordTestSession(result->port);
-
-        ASSERT_TRUE(expectedSession.has_value());
-        auto session = std::move(expectedSession).value();
-        session->start();
-        EXPECT_TRUE(session->isRunning());
-        session->stop();
-        EXPECT_FALSE(session->isRunning());
-    }
-
     TEST_F(SshSessionTests, CanConnectToSshServer)
     {
         auto [result, processThread] = createSshServer();
@@ -201,8 +180,6 @@ namespace SecureShell::Test
 
         channel1->close();
         channel2->close();
-
-        session->stop();
 
         EXPECT_GT(channel1Output.size(), 0);
         EXPECT_GT(channel2Output.size(), 0);
@@ -414,7 +391,6 @@ namespace SecureShell::Test
         ASSERT_EQ(awaiter2.get_future().wait_for(5s), std::future_status::ready);
 
         channel2->close();
-        session->stop();
 
         EXPECT_GT(channel2Output.size(), 0);
 


### PR DESCRIPTION
- Archive transfer scans now pop up as visible scans
- Archive transfers now have working transfer speed display
- Bulk download scan progress fixed
- Fixed #133 
- Fixed SSH Test Hangup #127 
- Added buffer provider for SFTP to avoid many alloc/dealloc and to leverage larger buffers for large files.