### PR TITLE
Prevent tests from failing when run im parallel.

### DIFF
--- a/ssh/test/ssh/common_fixture.hpp
+++ b/ssh/test/ssh/common_fixture.hpp
@@ -56,7 +56,7 @@ namespace SecureShell::Test
       protected:
         void SetUp() override
         {
-            std::ofstream privateKeyFile{programDirectory / "temp" / "key.private", std::ios_base::binary};
+            std::ofstream privateKeyFile{isolateDirectory_.path() / "key.private", std::ios_base::binary};
             privateKeyFile.write(privateKey, std::strlen(privateKey));
         }
 
@@ -172,7 +172,7 @@ namespace SecureShell::Test
             );
         }
 
-        Utility::TemporaryDirectory isolateDirectory_{programDirectory / "temp", false};
+        Utility::TemporaryDirectory isolateDirectory_{programDirectory / "temp", true};
         boost::asio::thread_pool pool_{1};
         nlohmann::json defaultPackageJson_ = nlohmann::json({
             {"name", "test"},

--- a/ssh/test/ssh/test_sftp.hpp
+++ b/ssh/test/ssh/test_sftp.hpp
@@ -24,13 +24,13 @@ namespace SecureShell::Test
 
         void TearDown() override
         {
-            if (std::filesystem::exists(programDirectory / "temp" / "log.txt"))
+            if (std::filesystem::exists(isolateDirectory_.path() / "log.txt"))
             {
                 if (!std::filesystem::exists(programDirectory / "logs"))
                     std::filesystem::create_directory(programDirectory / "logs");
 
                 std::filesystem::rename(
-                    programDirectory / "temp" / "log.txt",
+                    isolateDirectory_.path() / "log.txt",
                     programDirectory / "logs" /
                         ("log_"s + ::testing::UnitTest::GetInstance()->current_test_info()->test_case_name() + "_"s +
                          ::testing::UnitTest::GetInstance()->current_test_info()->name() + ".txt"));

--- a/ssh/test/ssh/test_ssh_session.hpp
+++ b/ssh/test/ssh/test_ssh_session.hpp
@@ -148,24 +148,32 @@ namespace SecureShell::Test
         std::string channel2Output{};
 
         std::promise<void> awaiter1{};
+        bool awaiter1Set = false;
         channelStartReading(
             channel1,
-            [&channel1Output, &awaiter1](std::string const& output)
+            [&channel1Output, &awaiter1, &awaiter1Set](std::string const& output)
             {
                 channel1Output += output;
-                if (channel1Output.find("bashrc") != std::string::npos)
+                if (!awaiter1Set && channel1Output.find("bashrc") != std::string::npos)
+                {
+                    awaiter1Set = true;
                     awaiter1.set_value();
+                }
             }
         );
 
         std::promise<void> awaiter2{};
+        bool awaiter2Set = false;
         channelStartReading(
             channel2,
-            [&channel2Output, &awaiter2](std::string const& output)
+            [&channel2Output, &awaiter2, &awaiter2Set](std::string const& output)
             {
                 channel2Output += output;
-                if (channel2Output.find("bashrc") != std::string::npos)
+                if (!awaiter2Set && channel2Output.find("bashrc") != std::string::npos)
+                {
+                    awaiter2Set = true;
                     awaiter2.set_value();
+                }
             }
         );
 
@@ -375,13 +383,17 @@ namespace SecureShell::Test
         channel1->close();
 
         std::promise<void> awaiter2{};
+        bool awaiter2Set = false;
         channelStartReading(
             channel2,
-            [&channel2Output, &awaiter2](std::string const& output)
+            [&channel2Output, &awaiter2, &awaiter2Set](std::string const& output)
             {
                 channel2Output += output;
-                if (channel2Output.find("bashrc") != std::string::npos)
+                if (!awaiter2Set && channel2Output.find("bashrc") != std::string::npos)
+                {
+                    awaiter2Set = true;
                     awaiter2.set_value();
+                }
             }
         );
 

--- a/ssh/test/ssh/test_ssh_session.hpp
+++ b/ssh/test/ssh/test_ssh_session.hpp
@@ -19,10 +19,10 @@ namespace SecureShell::Test
     {
         void TearDown() override
         {
-            if (std::filesystem::exists(programDirectory / "temp" / "log.txt"))
+            if (std::filesystem::exists(isolateDirectory_.path() / "log.txt"))
             {
                 std::filesystem::rename(
-                    programDirectory / "temp" / "log.txt",
+                    isolateDirectory_.path() / "log.txt",
                     programDirectory / "temp" /
                         ("log_"s + ::testing::UnitTest::GetInstance()->current_test_info()->test_case_name() + "_"s +
                             ::testing::UnitTest::GetInstance()->current_test_info()->name() + ".txt")


### PR DESCRIPTION
Temporary dirs now use random name feature.
Also fixes sporadically failing test that was poorly implemented and started failing during recent improvements (which is a good thing because the improvements made the poor test visible)